### PR TITLE
Spocan 59 | Validar JWT en llamadas posteriores a authorize

### DIFF
--- a/src/main/java/com/spochi/auth/AuthorizationException.java
+++ b/src/main/java/com/spochi/auth/AuthorizationException.java
@@ -1,3 +1,3 @@
-package com.spochi.auth.firebase;
+package com.spochi.auth;
 
 public class AuthorizationException extends RuntimeException {}

--- a/src/main/java/com/spochi/auth/JwtFilter.java
+++ b/src/main/java/com/spochi/auth/JwtFilter.java
@@ -73,7 +73,7 @@ public class JwtFilter extends OncePerRequestFilter {
             filterChain.doFilter(httpServletRequest, httpServletResponse);
 
         } catch (AuthorizationException | JwtException e) {
-            httpServletResponse.setStatus(HttpStatus.FORBIDDEN.value());
+            httpServletResponse.setStatus(HttpStatus.NOT_ACCEPTABLE.value());
             httpServletResponse.getWriter().write(INVALID_TOKEN_MESSAGE);
         }
     }

--- a/src/main/java/com/spochi/auth/JwtFilter.java
+++ b/src/main/java/com/spochi/auth/JwtFilter.java
@@ -5,6 +5,7 @@ import com.spochi.service.authenticate.JwtUtil;
 import io.jsonwebtoken.JwtException;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@Profile("!disable-jwt-filter")
 public class JwtFilter extends OncePerRequestFilter {
 
     @Autowired

--- a/src/main/java/com/spochi/auth/JwtFilter.java
+++ b/src/main/java/com/spochi/auth/JwtFilter.java
@@ -1,0 +1,69 @@
+package com.spochi.auth;
+
+import com.spochi.auth.firebase.AuthorizationException;
+import com.spochi.service.authenticate.JwtUtil;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    public static final String INVALID_TOKEN_MESSAGE = "Invalid or expired token";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    public static final String BEARER_SUFFIX = "Bearer ";
+
+    public JwtFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    private static final List<String> skippedEndpoints;
+
+    static {
+        skippedEndpoints = new ArrayList<>();
+
+        skippedEndpoints.add("/authenticate");
+        skippedEndpoints.add("/ping");
+    }
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest httpServletRequest, @NotNull HttpServletResponse httpServletResponse, @NotNull FilterChain filterChain) throws ServletException, IOException {
+        try {
+
+            if (!skippedEndpoints.contains(httpServletRequest.getRequestURI())) {
+                String authorizationHeader = httpServletRequest.getHeader(AUTHORIZATION_HEADER);
+
+                if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_SUFFIX)) {
+                    throw new AuthorizationException();
+                }
+
+                String token = authorizationHeader.substring(BEARER_SUFFIX.length());
+
+                if (!jwtUtil.isTokenValid(token)) {
+                    throw new AuthorizationException();
+                }
+            }
+
+            filterChain.doFilter(httpServletRequest, httpServletResponse);
+
+        } catch (AuthorizationException e) {
+            httpServletResponse.setStatus(HttpStatus.FORBIDDEN.value());
+            httpServletResponse.getWriter().write(INVALID_TOKEN_MESSAGE);
+        }
+    }
+}

--- a/src/main/java/com/spochi/auth/JwtFilter.java
+++ b/src/main/java/com/spochi/auth/JwtFilter.java
@@ -2,6 +2,7 @@ package com.spochi.auth;
 
 import com.spochi.auth.firebase.AuthorizationException;
 import com.spochi.service.authenticate.JwtUtil;
+import io.jsonwebtoken.JwtException;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -61,7 +62,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
             filterChain.doFilter(httpServletRequest, httpServletResponse);
 
-        } catch (AuthorizationException e) {
+        } catch (AuthorizationException | JwtException e) {
             httpServletResponse.setStatus(HttpStatus.FORBIDDEN.value());
             httpServletResponse.getWriter().write(INVALID_TOKEN_MESSAGE);
         }

--- a/src/main/java/com/spochi/auth/firebase/AuthorizationException.java
+++ b/src/main/java/com/spochi/auth/firebase/AuthorizationException.java
@@ -1,0 +1,3 @@
+package com.spochi.auth.firebase;
+
+public class AuthorizationException extends RuntimeException {}

--- a/src/main/java/com/spochi/auth/firebase/FirebaseAuthorizationException.java
+++ b/src/main/java/com/spochi/auth/firebase/FirebaseAuthorizationException.java
@@ -1,3 +1,0 @@
-package com.spochi.auth.firebase;
-
-public class FirebaseAuthorizationException extends RuntimeException {}

--- a/src/main/java/com/spochi/auth/firebase/FirebaseService.java
+++ b/src/main/java/com/spochi/auth/firebase/FirebaseService.java
@@ -1,12 +1,13 @@
 
 package com.spochi.auth.firebase;
 
+import com.spochi.auth.AuthorizationException;
 import com.spochi.auth.TokenInfo;
 import com.spochi.controller.exception.BadRequestException;
 import com.spochi.dto.UserResponseDTO;
 import com.spochi.service.UserService;
-import com.spochi.service.authenticate.firebase.FirebaseTokenProvider;
-import com.spochi.service.authenticate.JwtUtil;
+import com.spochi.service.auth.firebase.FirebaseTokenProvider;
+import com.spochi.service.auth.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;

--- a/src/main/java/com/spochi/auth/firebase/FirebaseService.java
+++ b/src/main/java/com/spochi/auth/firebase/FirebaseService.java
@@ -45,7 +45,7 @@ public class FirebaseService {
 
         } catch (Exception e) {
             System.out.println("Firebase authentication failed: " + e.getMessage());
-            throw new FirebaseAuthorizationException();
+            throw new AuthorizationException();
         }
     }
 }

--- a/src/main/java/com/spochi/controller/AuthenticateController.java
+++ b/src/main/java/com/spochi/controller/AuthenticateController.java
@@ -1,6 +1,6 @@
 package com.spochi.controller;
 
-import com.spochi.auth.firebase.AuthorizationException;
+import com.spochi.auth.AuthorizationException;
 import com.spochi.auth.firebase.FirebaseService;
 import com.spochi.auth.TokenInfo;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/spochi/controller/AuthenticateController.java
+++ b/src/main/java/com/spochi/controller/AuthenticateController.java
@@ -1,6 +1,6 @@
 package com.spochi.controller;
 
-import com.spochi.auth.firebase.FirebaseAuthorizationException;
+import com.spochi.auth.firebase.AuthorizationException;
 import com.spochi.auth.firebase.FirebaseService;
 import com.spochi.auth.TokenInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,8 +20,8 @@ public class AuthenticateController {
         return ResponseEntity.ok(firebaseService.parseToken(firebaseToken));
     }
 
-    @ExceptionHandler(value = {FirebaseAuthorizationException.class})
-    protected ResponseEntity<String> handleFirebaseAuthorizationException(FirebaseAuthorizationException e) {
+    @ExceptionHandler(value = {AuthorizationException.class})
+    protected ResponseEntity<String> handleFirebaseAuthorizationException(AuthorizationException e) {
         return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE)
                 .body("Invalid or expired token");
     }

--- a/src/main/java/com/spochi/service/auth/JwtUtil.java
+++ b/src/main/java/com/spochi/service/auth/JwtUtil.java
@@ -1,4 +1,4 @@
-package com.spochi.service.authenticate;
+package com.spochi.service.auth;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -40,6 +40,11 @@ public class JwtUtil {
         return extractAllClaims(token).getExpiration();
     }
 
+    /**
+     * Claims es un mapa clave valor con los distintos datos encriptados en el jwt
+     * Tiene claves fijas.
+     * En nuestro caso guardamos la expiración como EXPIRATION y el uid como SUBJECT
+     */
     private Claims extractAllClaims(String token) {
         return Jwts.parser().setSigningKey(getSecretKey()).parseClaimsJws(token).getBody();
     }

--- a/src/main/java/com/spochi/service/auth/firebase/FirebaseTokenProvider.java
+++ b/src/main/java/com/spochi/service/auth/firebase/FirebaseTokenProvider.java
@@ -1,4 +1,4 @@
-package com.spochi.service.authenticate.firebase;
+package com.spochi.service.auth.firebase;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;

--- a/src/main/java/com/spochi/service/authenticate/JwtUtil.java
+++ b/src/main/java/com/spochi/service/authenticate/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.spochi.service.authenticate;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,19 +17,43 @@ public class JwtUtil {
     @Value("${jwt.secret.key}")
     private String secretKey;
 
-    public String generateToken(String userId) {
+    public String generateToken(String uid) {
         Map<String, Object> claims = new HashMap<>();
-        return createToken(claims, userId);
+        return createToken(claims, uid);
+    }
+
+    public boolean isTokenValid(String token) {
+        return !isTokenExpired(token);
+    }
+
+    public String extractUid(String token) {
+        return extractAllClaims(token).getSubject();
     }
 
     private String createToken(Map<String, Object> claims, String subject) {
         return Jwts.builder().setClaims(claims).setSubject(subject).setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(24)))
+                .setExpiration(new Date(currentMillis() + TimeUnit.HOURS.toMillis(3)))
                 .signWith(SignatureAlgorithm.HS256, getSecretKey()).compact();
+    }
+
+    private Date extractExpiration(String token) {
+        return extractAllClaims(token).getExpiration();
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser().setSigningKey(getSecretKey()).parseClaimsJws(token).getBody();
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date(currentMillis()));
     }
 
     protected String getSecretKey() {
         return secretKey;
+    }
+
+    protected long currentMillis() {
+        return System.currentTimeMillis();
     }
 }
 

--- a/src/test/java/com/spochi/auth/JwtFilterTest.java
+++ b/src/test/java/com/spochi/auth/JwtFilterTest.java
@@ -1,0 +1,104 @@
+package com.spochi.auth;
+
+import com.spochi.service.authenticate.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("disable-firebase")
+class JwtFilterTest {
+    MockMvc mvc;
+
+    @Autowired
+    WebApplicationContext context;
+
+    @MockBean
+    JwtUtil jwtUtil;
+
+    @BeforeEach
+    void before() {
+        this.mvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilter(new JwtFilter(jwtUtil), "/*")
+                .build();
+    }
+
+
+    @Test
+    @DisplayName("do filter internal | when token is valid | ok")
+    void doFilterInternalTokenValid() throws Exception {
+        when(jwtUtil.isTokenValid(anyString())).thenReturn(true);
+
+        mvc.perform(get("/initiative/all")
+                .header(JwtFilter.AUTHORIZATION_HEADER, JwtFilter.BEARER_SUFFIX + " token"))
+                .andDo(print())
+                .andExpect(status().is(HttpStatus.OK.value()))
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("do filter internal | when token is invalid | should return status forbidden")
+    void doFilterInternalTokenInvalid() throws Exception {
+        when(jwtUtil.isTokenValid(anyString())).thenReturn(false);
+
+        final MvcResult result = mvc.perform(get("/initiative/all")
+                .header(JwtFilter.AUTHORIZATION_HEADER, JwtFilter.BEARER_SUFFIX + " token"))
+                .andDo(print())
+                .andExpect(status().is(HttpStatus.FORBIDDEN.value()))
+                .andReturn();
+
+        assertEquals(JwtFilter.INVALID_TOKEN_MESSAGE, result.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("do filter internal | when not sending header | should return status forbidden")
+    void doFilterInternalNoHeader() throws Exception {
+        when(jwtUtil.isTokenValid(anyString())).thenReturn(true);
+
+        final MvcResult result = mvc.perform(get("/initiative/all"))
+                .andDo(print())
+                .andExpect(status().is(HttpStatus.FORBIDDEN.value()))
+                .andReturn();
+
+        assertEquals(JwtFilter.INVALID_TOKEN_MESSAGE, result.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("do filter internal | when not sending Bearer sufix | should return status forbidden")
+    void doFilterInternalNoBearerSufix() throws Exception {
+        when(jwtUtil.isTokenValid(anyString())).thenReturn(true);
+
+        final MvcResult result = mvc.perform(get("/initiative/all")
+                .header(JwtFilter.AUTHORIZATION_HEADER, "no-bearer-token"))
+                .andDo(print())
+                .andExpect(status().is(HttpStatus.FORBIDDEN.value()))
+                .andReturn();
+
+        assertEquals(JwtFilter.INVALID_TOKEN_MESSAGE, result.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("do filter internal | when calling skipped endpoint | when not sending header | ok")
+    void doFilterInternalSkippedEndpoint() throws Exception {
+        mvc.perform(get("/ping"))
+                .andDo(print())
+                .andExpect(status().is(HttpStatus.OK.value()))
+                .andReturn();
+    }
+}

--- a/src/test/java/com/spochi/auth/JwtFilterTest.java
+++ b/src/test/java/com/spochi/auth/JwtFilterTest.java
@@ -60,7 +60,7 @@ class JwtFilterTest {
         final MvcResult result = mvc.perform(get("/initiative/all")
                 .header(JwtFilter.AUTHORIZATION_HEADER, JwtFilter.BEARER_SUFFIX + " token"))
                 .andDo(print())
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()))
+                .andExpect(status().is(HttpStatus.NOT_ACCEPTABLE.value()))
                 .andReturn();
 
         assertEquals(JwtFilter.INVALID_TOKEN_MESSAGE, result.getResponse().getContentAsString());
@@ -73,7 +73,7 @@ class JwtFilterTest {
 
         final MvcResult result = mvc.perform(get("/initiative/all"))
                 .andDo(print())
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()))
+                .andExpect(status().is(HttpStatus.NOT_ACCEPTABLE.value()))
                 .andReturn();
 
         assertEquals(JwtFilter.INVALID_TOKEN_MESSAGE, result.getResponse().getContentAsString());
@@ -81,13 +81,13 @@ class JwtFilterTest {
 
     @Test
     @DisplayName("do filter internal | when not sending Bearer sufix | should return status forbidden")
-    void doFilterInternalNoBearerSufix() throws Exception {
+    void doFilterInternalNoBearerSuffix() throws Exception {
         when(jwtUtil.isTokenValid(anyString())).thenReturn(true);
 
         final MvcResult result = mvc.perform(get("/initiative/all")
                 .header(JwtFilter.AUTHORIZATION_HEADER, "no-bearer-token"))
                 .andDo(print())
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()))
+                .andExpect(status().is(HttpStatus.NOT_ACCEPTABLE.value()))
                 .andReturn();
 
         assertEquals(JwtFilter.INVALID_TOKEN_MESSAGE, result.getResponse().getContentAsString());

--- a/src/test/java/com/spochi/auth/JwtFilterTest.java
+++ b/src/test/java/com/spochi/auth/JwtFilterTest.java
@@ -1,6 +1,6 @@
 package com.spochi.auth;
 
-import com.spochi.service.authenticate.JwtUtil;
+import com.spochi.service.auth.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/spochi/controller/AuthenticateControllerTest.java
+++ b/src/test/java/com/spochi/controller/AuthenticateControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.spochi.service.authenticate.JwtUtil;
 import com.spochi.auth.TokenInfo;
-import com.spochi.auth.firebase.FirebaseAuthorizationException;
+import com.spochi.auth.firebase.AuthorizationException;
 import com.spochi.service.authenticate.firebase.FirebaseTokenProvider;
 import com.spochi.controller.exception.BadRequestException;
 import com.spochi.dto.UserResponseDTO;
@@ -85,7 +85,7 @@ class AuthenticateControllerTest {
                 .andExpect(status().is(HttpStatus.NOT_ACCEPTABLE.value()))
                 .andReturn();
 
-        assertTrue(result.getResolvedException() instanceof FirebaseAuthorizationException);
+        assertTrue(result.getResolvedException() instanceof AuthorizationException);
         assertEquals("Invalid or expired token", result.getResponse().getContentAsString());
     }
 

--- a/src/test/java/com/spochi/controller/AuthenticateControllerTest.java
+++ b/src/test/java/com/spochi/controller/AuthenticateControllerTest.java
@@ -2,10 +2,10 @@ package com.spochi.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.auth.FirebaseAuthException;
-import com.spochi.service.authenticate.JwtUtil;
+import com.spochi.service.auth.JwtUtil;
 import com.spochi.auth.TokenInfo;
-import com.spochi.auth.firebase.AuthorizationException;
-import com.spochi.service.authenticate.firebase.FirebaseTokenProvider;
+import com.spochi.auth.AuthorizationException;
+import com.spochi.service.auth.firebase.FirebaseTokenProvider;
 import com.spochi.controller.exception.BadRequestException;
 import com.spochi.dto.UserResponseDTO;
 import com.spochi.service.UserService;

--- a/src/test/java/com/spochi/controller/AuthenticateControllerTest.java
+++ b/src/test/java/com/spochi/controller/AuthenticateControllerTest.java
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("disable-firebase")
+@ActiveProfiles(profiles = {"disable-firebase", "disable-jwt-filter"})
 class AuthenticateControllerTest {
     @Autowired
     MockMvc mvc;

--- a/src/test/java/com/spochi/controller/InitiativeIntegrationTest.java
+++ b/src/test/java/com/spochi/controller/InitiativeIntegrationTest.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("disable-firebase")
+@ActiveProfiles(profiles = {"disable-firebase", "disable-jwt-filter"})
 class InitiativeIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/spochi/controller/InitiativeTestUtil.java
+++ b/src/test/java/com/spochi/controller/InitiativeTestUtil.java
@@ -2,7 +2,6 @@ package com.spochi.controller;
 
 import com.spochi.dto.InitiativeResponseDTO;
 import com.spochi.entity.Initiative;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Instant;
 import java.time.LocalDateTime;

--- a/src/test/java/com/spochi/controller/PingControllerTest.java
+++ b/src/test/java/com/spochi/controller/PingControllerTest.java
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("disable-firebase")
+@ActiveProfiles(profiles = {"disable-firebase", "disable-jwt-filter"})
 class PingControllerTest {
 
     @Autowired

--- a/src/test/java/com/spochi/dto/DTOComparisonUtilTest.java
+++ b/src/test/java/com/spochi/dto/DTOComparisonUtilTest.java
@@ -1,7 +1,6 @@
 package com.spochi.dto;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/spochi/repository/UserRepositoryTest.java
+++ b/src/test/java/com/spochi/repository/UserRepositoryTest.java
@@ -5,7 +5,6 @@ import com.spochi.persistence.UserDummyBuilder;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/spochi/service/auth/JwtUtilForTest.java
+++ b/src/test/java/com/spochi/service/auth/JwtUtilForTest.java
@@ -1,4 +1,4 @@
-package com.spochi.service.authenticate;
+package com.spochi.service.auth;
 
 import java.util.function.Supplier;
 

--- a/src/test/java/com/spochi/service/auth/JwtUtilTest.java
+++ b/src/test/java/com/spochi/service/auth/JwtUtilTest.java
@@ -1,4 +1,4 @@
-package com.spochi.service.authenticate;
+package com.spochi.service.auth;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/spochi/service/authenticate/JwtUtilForTest.java
+++ b/src/test/java/com/spochi/service/authenticate/JwtUtilForTest.java
@@ -1,8 +1,25 @@
 package com.spochi.service.authenticate;
 
+import java.util.function.Supplier;
+
 public class JwtUtilForTest extends JwtUtil {
+    private final Supplier<Long> currentMillisSupplier;
+
+    public JwtUtilForTest(Supplier<Long> currentMillisSupplier) {
+        this.currentMillisSupplier = currentMillisSupplier;
+    }
+
+    public JwtUtilForTest() {
+        this(System::currentTimeMillis);
+    }
+
     @Override
     protected String getSecretKey() {
         return "secret";
+    }
+
+    @Override
+    protected long currentMillis() {
+        return currentMillisSupplier.get();
     }
 }

--- a/src/test/java/com/spochi/service/authenticate/JwtUtilTest.java
+++ b/src/test/java/com/spochi/service/authenticate/JwtUtilTest.java
@@ -1,16 +1,50 @@
 package com.spochi.service.authenticate;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @ActiveProfiles("disable-firebase")
 class JwtUtilTest {
+
     @Test
+    @DisplayName("generate token | ok")
     void generateToken() {
-        assertNotNull(new JwtUtilForTest().generateToken("token"));
+        assertNotNull(new JwtUtilForTest().generateToken("uid"));
+    }
+
+    @Test
+    @DisplayName("extract uid | ok")
+    void extractUid() {
+        final JwtUtilForTest jwtUtil = new JwtUtilForTest();
+        final String jwt = jwtUtil.generateToken("uid");
+
+        assertEquals("uid", jwtUtil.extractUid(jwt));
+    }
+
+    @Test
+    @DisplayName("is token valid | when token is expired | should return false")
+    void tokenExpiredAfterThreeHours() {
+        final JwtUtilForTest jwtUtilNow = new JwtUtilForTest();
+        final String jwt = jwtUtilNow.generateToken("uid");
+        final long millisAfterThreeHoursAndOneMinute = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(3L) + TimeUnit.MINUTES.toMillis(1L);
+        final JwtUtilForTest jwtUtilAfterThreeHoursAndOneMinute = new JwtUtilForTest(() -> millisAfterThreeHoursAndOneMinute);
+
+        assertFalse(jwtUtilAfterThreeHoursAndOneMinute.isTokenValid(jwt));
+    }
+
+    @Test
+    @DisplayName("is token valid | when token is not expired | should return true")
+    void tokenNotExpiredAfterTwoHours() {
+        final JwtUtilForTest jwtUtilNow = new JwtUtilForTest();
+        final String jwt = jwtUtilNow.generateToken("uid");
+        final long millisAfterTwoHours = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2L);
+        final JwtUtilForTest jwtUtilAfterThreeHoursAndOneMinute = new JwtUtilForTest(() -> millisAfterTwoHours);
+
+        assertTrue(jwtUtilAfterThreeHoursAndOneMinute.isTokenValid(jwt));
     }
 }


### PR DESCRIPTION
Se interceptan todas las invocaciones al backend para validar el JWT generado en la autorización