### PR TITLE
SPOCAN-54 | Obtener Uid desde cualquier controller

### DIFF
--- a/src/main/java/com/spochi/auth/firebase/FirebaseService.java
+++ b/src/main/java/com/spochi/auth/firebase/FirebaseService.java
@@ -35,7 +35,7 @@ public class FirebaseService {
 
             final String jwt = jwtUtil.generateToken(uid);
 
-            final UserResponseDTO user = userService.findByGoogleId(uid);
+            final UserResponseDTO user = userService.findByUid(uid);
 
             final TokenInfo tokenInfo = new TokenInfo();
             tokenInfo.setJwt(jwt);

--- a/src/main/java/com/spochi/config/WebConfig.java
+++ b/src/main/java/com/spochi/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.spochi.config;
+
+import com.spochi.controller.handler.UidHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Autowired
+    UidHandler uidHandler;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(uidHandler);
+    }
+}

--- a/src/main/java/com/spochi/controller/handler/Uid.java
+++ b/src/main/java/com/spochi/controller/handler/Uid.java
@@ -1,0 +1,15 @@
+package com.spochi.controller.handler;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Esto es una anotación custom que permite identificar cualquier tipo de objetos
+ * entre los parámetros de un controller
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Uid {}

--- a/src/main/java/com/spochi/controller/handler/UidHandler.java
+++ b/src/main/java/com/spochi/controller/handler/UidHandler.java
@@ -1,0 +1,50 @@
+package com.spochi.controller.handler;
+
+import com.spochi.service.auth.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static com.spochi.auth.JwtFilter.AUTHORIZATION_HEADER;
+import static com.spochi.auth.JwtFilter.BEARER_SUFFIX;
+
+@Component
+public class UidHandler implements HandlerMethodArgumentResolver {
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    public UidHandler(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    // Chequeo si el método invocado tiene un parámetro anotado con @Uid
+    @Override
+    public boolean supportsParameter(MethodParameter methodParameter) {
+        return methodParameter.getParameterAnnotation(Uid.class) != null;
+    }
+
+    // si llegó hasta este punto es porque el JwtFilter validó que el token sea válido, entonces no puede faltar el header
+    @Override
+    public Object resolveArgument(MethodParameter methodParameter, ModelAndViewContainer modelAndViewContainer, NativeWebRequest nativeWebRequest, WebDataBinderFactory webDataBinderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) nativeWebRequest.getNativeRequest();
+        final String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+        String token = authorizationHeader.substring(BEARER_SUFFIX.length());
+
+        return jwtUtil.extractUid(token);
+    }
+
+    // Ejemplo de uso
+    /*
+        @GetMapping("/something")
+        public String getSomething(@Uid String uid) {
+            return service.getSomething(uid);
+        }
+     */
+    // El handler inyecta el parámetro uid extraído del token bearer
+}

--- a/src/main/java/com/spochi/repository/UserRepository.java
+++ b/src/main/java/com/spochi/repository/UserRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends MongoRepository<User, String> {
-    Optional<User> findByGoogleId(String googleId);
+    // todo cambiar a findByUid cuando se cambie googleId por uid en User
+    Optional<User> findByGoogleId(String uid);
 }

--- a/src/main/java/com/spochi/service/UserService.java
+++ b/src/main/java/com/spochi/service/UserService.java
@@ -11,8 +11,8 @@ public class UserService {
     @Autowired
     UserRepository repository;
 
-    public UserResponseDTO findByGoogleId(String googleId) {
-        return repository.findByGoogleId(googleId)
+    public UserResponseDTO findByUid(String uid) {
+        return repository.findByGoogleId(uid)
                 .map(User::toDTO)
                 .orElse(null);
     }

--- a/src/test/java/com/spochi/controller/AuthenticateControllerTest.java
+++ b/src/test/java/com/spochi/controller/AuthenticateControllerTest.java
@@ -99,7 +99,7 @@ class AuthenticateControllerTest {
         expectedDTO.setNickname("user");
         expectedDTO.setType_id(1);
 
-        when(userService.findByGoogleId(anyString())).thenReturn(expectedDTO);
+        when(userService.findByUid(anyString())).thenReturn(expectedDTO);
         when(tokenProvider.getUidFromToken(anyString())).thenReturn("user-uid");
         when(jwtUtil.generateToken(anyString())).thenReturn("jwt");
 

--- a/src/test/java/com/spochi/handler/UidHandlerTest.java
+++ b/src/test/java/com/spochi/handler/UidHandlerTest.java
@@ -1,0 +1,63 @@
+package com.spochi.handler;
+
+import com.spochi.controller.handler.Uid;
+import com.spochi.controller.handler.UidHandler;
+import com.spochi.service.auth.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static com.spochi.auth.JwtFilter.AUTHORIZATION_HEADER;
+import static com.spochi.auth.JwtFilter.BEARER_SUFFIX;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UidHandlerTest {
+
+    @Test
+    @DisplayName("supports parameter | when method is annotated with @Uid | should return true")
+    void testSupportsParameterTrue() throws NoSuchMethodException {
+        final UidHandler uidHandler = new UidHandler(new JwtUtil());
+        final MethodParameter method = new MethodParameter(this.getClass().getDeclaredMethod("methodWithUidAnnotation", String.class), 0);
+
+        assertTrue(uidHandler.supportsParameter(method));
+    }
+
+    @Test
+    @DisplayName("supports parameter | when method is not annotated with @Uid | should return false")
+    void testSupportsParameterFalse() throws NoSuchMethodException {
+        final UidHandler uidHandler = new UidHandler(new JwtUtil());
+        final MethodParameter method = new MethodParameter(this.getClass().getDeclaredMethod("methodWithoutUidAnnotation", String.class), 0);
+
+        assertFalse(uidHandler.supportsParameter(method));
+    }
+
+    @Test
+    @DisplayName("resolve argument | when authorization header is present | should return uid")
+    void testResolveArgumentOk() throws Exception {
+        final JwtUtil jwtUtilMock = mock(JwtUtil.class);
+
+        when(jwtUtilMock.extractUid(anyString())).thenReturn("uid");
+
+        final UidHandler uidHandler = new UidHandler(jwtUtilMock);
+        final NativeWebRequest nativeWebRequest = mock(NativeWebRequest.class);
+        final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+
+        when(httpServletRequest.getHeader(AUTHORIZATION_HEADER)).thenReturn(BEARER_SUFFIX +  "jwt");
+        when(nativeWebRequest.getNativeRequest()).thenReturn(httpServletRequest);
+
+        final Object uid = uidHandler.resolveArgument(mock(MethodParameter.class), mock(ModelAndViewContainer.class), nativeWebRequest, mock(WebDataBinderFactory.class));
+
+        assertEquals("uid", uid.toString());
+    }
+
+    private void methodWithUidAnnotation(@Uid String uid) {}
+    private void methodWithoutUidAnnotation(String uid) {}
+}

--- a/src/test/java/com/spochi/service/UserServiceTest.java
+++ b/src/test/java/com/spochi/service/UserServiceTest.java
@@ -36,7 +36,7 @@ class UserServiceTest {
 
         when(repository.findByGoogleId(anyString())).thenReturn(Optional.of(mockedUser));
 
-        final UserResponseDTO actualDTO = service.findByGoogleId("google-id");
+        final UserResponseDTO actualDTO = service.findByUid("google-id");
 
         assertEquals(expectedDto, actualDTO);
     }
@@ -45,6 +45,6 @@ class UserServiceTest {
     @DisplayName("find by google id | when user is not found | should return null | ok")
     void findByGoogleIdNotFound() {
         when(repository.findByGoogleId(anyString())).thenReturn(Optional.empty());
-        assertNull(service.findByGoogleId("google-id"));
+        assertNull(service.findByUid("google-id"));
     }
 }


### PR DESCRIPTION
- Se agrega la clase UidHandler para interceptar el token y obtener el Uid en todos los endpoints que lo requieran
- Se agrega clase WebConfig para inyectar el handler
- Se agrega la anotación @Uid para especificar desde el endpoint que se requiere interceptar el dato
- Los servicios que utilicen esta funcionalidad podrán comunicarse con UserService.findByUid() para obtener el UserDTO o con UserRepository.findByGoogleId() para obtener el User
- Se cambia findByGoogleId() por findByUid() para más claridad