### PR TITLE
SPOCAN-52 | Consulta de Iniciativas getAll optimizada por batches

### DIFF
--- a/src/main/java/com/spochi/controller/InitiativeController.java
+++ b/src/main/java/com/spochi/controller/InitiativeController.java
@@ -5,7 +5,6 @@ import com.spochi.dto.InitiativeRequestDTO;
 import com.spochi.dto.InitiativeResponseDTO;
 import com.spochi.service.InitiativeService;
 import com.spochi.service.query.InitiativeQuery;
-import com.spochi.service.query.InitiativeSorter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,16 +19,18 @@ public class InitiativeController {
 
     @GetMapping("/all")
     public List<InitiativeResponseDTO> getAll(@RequestParam (required = false) Integer order,
-                                              @RequestParam (required = false) Integer statusId,
-                                              @RequestParam (required = false) Boolean currentUser,
-                                              @RequestParam (required = false) String dateFrom,
+                                              @RequestParam (required = false) Integer[] statusId,
+                                              @RequestParam (required = false) boolean currentUser,
+                                              @RequestParam (required = false) String dateTop,
+                                              @RequestParam (required = false) Integer limit,
                                               @Uid String uid) {
 
         final InitiativeQuery query = new InitiativeQuery();
 
         query.withSorter(order);
-        query.withStatus(statusId);
-        query.withDateFrom(dateFrom);
+        query.withStatuses(statusId);
+        query.withDateTop(dateTop);
+        query.withLimit(limit);
 
         return service.getAll(query, uid, currentUser);
     }

--- a/src/main/java/com/spochi/controller/InitiativeController.java
+++ b/src/main/java/com/spochi/controller/InitiativeController.java
@@ -4,6 +4,7 @@ import com.spochi.controller.handler.Uid;
 import com.spochi.dto.InitiativeRequestDTO;
 import com.spochi.dto.InitiativeResponseDTO;
 import com.spochi.service.InitiativeService;
+import com.spochi.service.query.InitiativeQuery;
 import com.spochi.service.query.InitiativeSorter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -18,16 +19,19 @@ public class InitiativeController {
     InitiativeService service;
 
     @GetMapping("/all")
-    public List<InitiativeResponseDTO> getAll(@RequestParam (required = false) Integer order, @Uid String uid) {
-        final InitiativeSorter sorter;
+    public List<InitiativeResponseDTO> getAll(@RequestParam (required = false) Integer order,
+                                              @RequestParam (required = false) Integer statusId,
+                                              @RequestParam (required = false) Boolean currentUser,
+                                              @RequestParam (required = false) String dateFrom,
+                                              @Uid String uid) {
 
-        if (order != null) {
-            sorter = InitiativeSorter.fromIdOrElseThrow(order);
-        } else {
-            sorter = InitiativeSorter.DEFAULT_COMPARATOR;
-        }
+        final InitiativeQuery query = new InitiativeQuery();
 
-        return service.getAll(sorter, uid);
+        query.withSorter(order);
+        query.withStatus(statusId);
+        query.withDateFrom(dateFrom);
+
+        return service.getAll(query, uid, currentUser);
     }
 
     @PostMapping

--- a/src/main/java/com/spochi/controller/InitiativeController.java
+++ b/src/main/java/com/spochi/controller/InitiativeController.java
@@ -23,6 +23,7 @@ public class InitiativeController {
                                               @RequestParam (required = false) boolean currentUser,
                                               @RequestParam (required = false) String dateTop,
                                               @RequestParam (required = false) Integer limit,
+                                              @RequestParam (required = false) Integer offset,
                                               @Uid String uid) {
 
         final InitiativeQuery query = new InitiativeQuery();
@@ -31,6 +32,7 @@ public class InitiativeController {
         query.withStatuses(statusId);
         query.withDateTop(dateTop);
         query.withLimit(limit);
+        query.withOffset(offset);
 
         return service.getAll(query, uid, currentUser);
     }

--- a/src/main/java/com/spochi/controller/PingController.java
+++ b/src/main/java/com/spochi/controller/PingController.java
@@ -1,31 +1,14 @@
 package com.spochi.controller;
 
-import com.spochi.entity.Initiative;
-import com.spochi.repository.InitiativeRepository;
-import com.spochi.service.query.InitiativeQuery;
-import com.spochi.util.DateUtil;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 
 @RestController
 public class PingController {
 
-    @Autowired
-    InitiativeRepository initiativeRepository;
-
     @GetMapping("/ping")
     public String ping() {
-        final InitiativeQuery query = new InitiativeQuery();
-        query.withLimit(2);
-        query.withDateTop(DateUtil.milliToDateUTC(1618200872038L).toString());
-        query.withStatuses(new Integer[1]);
-        query.withSorter(1);
-
-        final List<Initiative> allInitiatives = initiativeRepository.getAllInitiatives(query);
         return "pong";
     }
 }

--- a/src/main/java/com/spochi/controller/PingController.java
+++ b/src/main/java/com/spochi/controller/PingController.java
@@ -1,14 +1,23 @@
 package com.spochi.controller;
 
+import com.spochi.entity.Initiative;
+import com.spochi.repository.InitiativeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
 
 
 @RestController
 public class PingController {
 
+    @Autowired
+    InitiativeRepository initiativeRepository;
+
     @GetMapping("/ping")
     public String ping() {
+        final Optional<Initiative> initiativeById = initiativeRepository.findInitiativeById("urn:ngsi-ld:Initiative:001");
         return "pong";
     }
 }

--- a/src/main/java/com/spochi/controller/PingController.java
+++ b/src/main/java/com/spochi/controller/PingController.java
@@ -2,11 +2,13 @@ package com.spochi.controller;
 
 import com.spochi.entity.Initiative;
 import com.spochi.repository.InitiativeRepository;
+import com.spochi.service.query.InitiativeQuery;
+import com.spochi.util.DateUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Optional;
+import java.util.List;
 
 
 @RestController
@@ -17,7 +19,13 @@ public class PingController {
 
     @GetMapping("/ping")
     public String ping() {
-        final Optional<Initiative> initiativeById = initiativeRepository.findInitiativeById("urn:ngsi-ld:Initiative:001");
+        final InitiativeQuery query = new InitiativeQuery();
+        query.withLimit(2);
+        query.withDateTop(DateUtil.milliToDateUTC(1618200872038L).toString());
+        query.withStatuses(new Integer[1]);
+        query.withSorter(1);
+
+        final List<Initiative> allInitiatives = initiativeRepository.getAllInitiatives(query);
         return "pong";
     }
 }

--- a/src/main/java/com/spochi/dto/InitiativeResponseDTO.java
+++ b/src/main/java/com/spochi/dto/InitiativeResponseDTO.java
@@ -10,13 +10,8 @@ public class InitiativeResponseDTO {
     private String date;
     private String nickname;
     private int status_id;
-    private boolean from_current_user;
 
-
-
-    public InitiativeResponseDTO(){
-
-    }
+    public InitiativeResponseDTO(){}
 
     public String get_id() {
         return _id;
@@ -66,9 +61,6 @@ public class InitiativeResponseDTO {
         this.status_id = status_id;
     }
 
-    public boolean isFrom_current_user() {return from_current_user;}
-
-    public void setFrom_current_user(boolean from_current_user) {this.from_current_user = from_current_user;}
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof InitiativeResponseDTO)) return false;
@@ -79,7 +71,6 @@ public class InitiativeResponseDTO {
                 nullOrEquals(this.description, other.description) &&
                 nullOrEquals(this.image, other.image) &&
                 nullOrEquals(this.status_id, other.status_id) &&
-                nullOrEquals(this._id, other._id)&&
-                nullOrEquals(this.from_current_user,other.from_current_user);
+                nullOrEquals(this._id, other._id);
     }
 }

--- a/src/main/java/com/spochi/entity/Initiative.java
+++ b/src/main/java/com/spochi/entity/Initiative.java
@@ -2,6 +2,7 @@ package com.spochi.entity;
 
 import com.spochi.dto.InitiativeResponseDTO;
 import com.spochi.repository.fiware.ngsi.*;
+import com.spochi.util.DateUtil;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -66,7 +67,7 @@ public class Initiative implements NGSISerializable {
         json.addAttribute(Fields.DESCRIPTION, this.description);
         json.addAttribute(Fields.IMAGE, this.image);
         json.addAttribute(Fields.NICKNAME, this.nickname);
-        json.addAttribute(Fields.DATE, this.date.withNano(0).toString());
+        json.addAttribute(Fields.DATE, DateUtil.dateToMilliUTC(this.date));
         json.addAttribute(Fields.USER_ID, this.userId);
         json.addAttribute(Fields.STATUS_ID, this.statusId);
 
@@ -79,7 +80,7 @@ public class Initiative implements NGSISerializable {
         DESCRIPTION("description", NGSIFieldType.TEXT),
         IMAGE("image", NGSIFieldType.TEXT),
         NICKNAME("nickname", NGSIFieldType.TEXT),
-        DATE("date", NGSIFieldType.DATE),
+        DATE("date", NGSIFieldType.LONG),
         USER_ID("refUser", NGSIFieldType.REFERENCE),
         STATUS_ID("status_id", NGSIFieldType.INTEGER);
 

--- a/src/main/java/com/spochi/entity/Initiative.java
+++ b/src/main/java/com/spochi/entity/Initiative.java
@@ -43,7 +43,7 @@ public class Initiative implements NGSISerializable {
         this.statusId = statusId;
     }
 
-    public InitiativeResponseDTO toDTO(String user_id) {
+    public InitiativeResponseDTO toDTO() {
         final InitiativeResponseDTO dto = new InitiativeResponseDTO();
 
         dto.set_id(this._id);
@@ -52,7 +52,6 @@ public class Initiative implements NGSISerializable {
         dto.setNickname(this.nickname);
         dto.setStatus_id(this.statusId);
         dto.setImage(this.image);
-        dto.setFrom_current_user(user_id.equals(this.userId));
 
         return dto;
     }

--- a/src/main/java/com/spochi/repository/InitiativeRepository.java
+++ b/src/main/java/com/spochi/repository/InitiativeRepository.java
@@ -4,12 +4,11 @@ import com.spochi.entity.Initiative;
 import com.spochi.service.query.InitiativeQuery;
 import com.spochi.service.query.InitiativeSorter;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 public interface InitiativeRepository extends EntityRepository<Initiative> {
     List<Initiative> getAllInitiatives(InitiativeSorter sorter);
-    default List<Initiative> getAllInitiatives(InitiativeQuery query) {return new ArrayList<>();}
+    List<Initiative> getAllInitiatives(InitiativeQuery query);
     Optional<Initiative> findInitiativeById(String id);
 }

--- a/src/main/java/com/spochi/repository/InitiativeRepository.java
+++ b/src/main/java/com/spochi/repository/InitiativeRepository.java
@@ -2,13 +2,11 @@ package com.spochi.repository;
 
 import com.spochi.entity.Initiative;
 import com.spochi.service.query.InitiativeQuery;
-import com.spochi.service.query.InitiativeSorter;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface InitiativeRepository extends EntityRepository<Initiative> {
-    List<Initiative> getAllInitiatives(InitiativeSorter sorter);
     List<Initiative> getAllInitiatives(InitiativeQuery query);
     Optional<Initiative> findInitiativeById(String id);
 }

--- a/src/main/java/com/spochi/repository/InitiativeRepository.java
+++ b/src/main/java/com/spochi/repository/InitiativeRepository.java
@@ -1,13 +1,15 @@
 package com.spochi.repository;
 
-import com.spochi.dto.InitiativeResponseDTO;
 import com.spochi.entity.Initiative;
+import com.spochi.service.query.InitiativeQuery;
 import com.spochi.service.query.InitiativeSorter;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 public interface InitiativeRepository extends EntityRepository<Initiative> {
     List<Initiative> getAllInitiatives(InitiativeSorter sorter);
+    default List<Initiative> getAllInitiatives(InitiativeQuery query) {return new ArrayList<>();}
     Optional<Initiative> findInitiativeById(String id);
 }

--- a/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
+++ b/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
@@ -26,6 +26,17 @@ public class FiwareInitiativeRepository extends FiwareRepository<Initiative> imp
     }
 
     @Override
+    public Optional<Initiative> findInitiativeById(String id) {
+        return findById(id);
+    }
+
+    @Override
+    public List<Initiative> getAllInitiatives(InitiativeQuery query) {
+        final NGSIQueryBuilder queryBuilder = parseInitiativeQuery(query);
+        return find(queryBuilder);
+    }
+
+    @Override
     protected NGSIEntityType getEntityType() {
         return Initiative.NGSIType;
     }
@@ -44,17 +55,6 @@ public class FiwareInitiativeRepository extends FiwareRepository<Initiative> imp
         final int statusId = InitiativeStatus.fromIdOrElseThrow(json.getInt(Initiative.Fields.STATUS_ID)).getId();
 
         return new Initiative(id, description, image, nickname, date, userId, statusId);
-    }
-
-    @Override
-    public Optional<Initiative> findInitiativeById(String id) {
-        return findById(id);
-    }
-
-    @Override
-    public List<Initiative> getAllInitiatives(InitiativeQuery query) {
-        final NGSIQueryBuilder queryBuilder = parseInitiativeQuery(query);
-        return find(queryBuilder);
     }
 
     private NGSIQueryBuilder parseInitiativeQuery(InitiativeQuery initiativeQuery) {

--- a/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
+++ b/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
@@ -69,8 +69,8 @@ public class FiwareInitiativeRepository extends FiwareRepository<Initiative> imp
         }
 
         if (initiativeQuery.getStatuses() != null) {
-            initiativeQuery.getStatuses()
-                    .forEach(status -> ngsiQueryBuilder.attributeEq(Initiative.Fields.STATUS_ID, String.valueOf(status.getId())));
+            ngsiQueryBuilder.attributeEq(Initiative.Fields.STATUS_ID,
+                    initiativeQuery.getStatuses().stream().map(s -> String.valueOf(s.getId())).toArray(String[]::new));
         }
 
         if (initiativeQuery.getDateTop() != null) {

--- a/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
+++ b/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
@@ -68,7 +68,6 @@ public class FiwareInitiativeRepository extends FiwareRepository<Initiative> imp
         return find(queryBuilder);
     }
 
-    // todo cuando va por refUser se caga en el resto de los filtos
     private NGSIQueryBuilder parseInitiativeQuery(InitiativeQuery initiativeQuery) {
         final NGSIQueryBuilder ngsiQueryBuilder = new NGSIQueryBuilder();
 
@@ -92,6 +91,10 @@ public class FiwareInitiativeRepository extends FiwareRepository<Initiative> imp
 
         if (initiativeQuery.getLimit() != null) {
             ngsiQueryBuilder.limit(initiativeQuery.getLimit());
+        }
+
+        if (initiativeQuery.getOffset() != null) {
+            ngsiQueryBuilder.offset(initiativeQuery.getOffset());
         }
 
         return ngsiQueryBuilder;

--- a/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
+++ b/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
@@ -4,7 +4,6 @@ import com.spochi.entity.Initiative;
 import com.spochi.entity.InitiativeStatus;
 import com.spochi.entity.User;
 import com.spochi.repository.InitiativeRepository;
-import com.spochi.repository.fiware.ngsi.NGSICommonFields;
 import com.spochi.repository.fiware.ngsi.NGSIEntityType;
 import com.spochi.repository.fiware.ngsi.NGSIJson;
 import com.spochi.repository.fiware.ngsi.NGSIQueryBuilder;
@@ -15,9 +14,7 @@ import com.spochi.util.DateUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.*;
 
 @Repository
@@ -67,31 +64,34 @@ public class FiwareInitiativeRepository extends FiwareRepository<Initiative> imp
 
     @Override
     public List<Initiative> getAllInitiatives(InitiativeQuery query) {
-        final NGSIQueryBuilder queryBuilder = parseQuery(query);
-        return new ArrayList<>();
+        final NGSIQueryBuilder queryBuilder = parseInitiativeQuery(query);
+        return find(queryBuilder);
     }
 
-    private NGSIQueryBuilder parseQuery(InitiativeQuery initiativeQuery) {
+    // todo cuando va por refUser se caga en el resto de los filtos
+    private NGSIQueryBuilder parseInitiativeQuery(InitiativeQuery initiativeQuery) {
         final NGSIQueryBuilder ngsiQueryBuilder = new NGSIQueryBuilder();
 
         if (initiativeQuery.getUserId() != null) {
             ngsiQueryBuilder.ref(User.NGSIType, initiativeQuery.getUserId());
         }
 
-        if (initiativeQuery.getSorter() != null) {
-            if (initiativeQuery.getSorter() == InitiativeSorter.DATE_DESC) {
-                ngsiQueryBuilder.orderByDesc(Initiative.Fields.DATE);
-            }
+        if (initiativeQuery.getSorter() == InitiativeSorter.DATE_DESC) {
+            ngsiQueryBuilder.orderByDesc(Initiative.Fields.DATE);
         }
 
-        if (initiativeQuery.getStatus() != null) {
-            ngsiQueryBuilder.attribute(Initiative.Fields.STATUS_ID, String.valueOf(initiativeQuery.getStatus().getId()));
+        if (initiativeQuery.getStatuses() != null) {
+            initiativeQuery.getStatuses()
+                    .forEach(status -> ngsiQueryBuilder.attributeEq(Initiative.Fields.STATUS_ID, String.valueOf(status.getId())));
         }
 
-        // todo guardar milisegundos en iniciativas para poder comparar
-        if (initiativeQuery.getDateFrom() != null) {
-            final long millis = initiativeQuery.getDateFrom().atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
+        if (initiativeQuery.getDateTop() != null) {
+            final long milli = DateUtil.dateToMilliUTC(initiativeQuery.getDateTop());
+            ngsiQueryBuilder.attributeLs(Initiative.Fields.DATE, String.valueOf(milli));
+        }
 
+        if (initiativeQuery.getLimit() != null) {
+            ngsiQueryBuilder.limit(initiativeQuery.getLimit());
         }
 
         return ngsiQueryBuilder;

--- a/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
+++ b/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
@@ -47,17 +47,6 @@ public class FiwareInitiativeRepository extends FiwareRepository<Initiative> imp
     }
 
     @Override
-    public List<Initiative> getAllInitiatives(InitiativeSorter sorter) {
-
-        final NGSIQueryBuilder builder = new NGSIQueryBuilder();
-
-        if (sorter == InitiativeSorter.DATE_DESC) {
-            builder.orderByDesc(Initiative.Fields.DATE);
-        }
-        return find(builder);
-    }
-
-    @Override
     public Optional<Initiative> findInitiativeById(String id) {
         return findById(id);
     }

--- a/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
+++ b/src/main/java/com/spochi/repository/fiware/FiwareInitiativeRepository.java
@@ -2,16 +2,22 @@ package com.spochi.repository.fiware;
 
 import com.spochi.entity.Initiative;
 import com.spochi.entity.InitiativeStatus;
+import com.spochi.entity.User;
 import com.spochi.repository.InitiativeRepository;
+import com.spochi.repository.fiware.ngsi.NGSICommonFields;
 import com.spochi.repository.fiware.ngsi.NGSIEntityType;
 import com.spochi.repository.fiware.ngsi.NGSIJson;
 import com.spochi.repository.fiware.ngsi.NGSIQueryBuilder;
 import com.spochi.repository.fiware.rest.RestPerformer;
+import com.spochi.service.query.InitiativeQuery;
 import com.spochi.service.query.InitiativeSorter;
+import com.spochi.util.DateUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 
 @Repository
@@ -29,12 +35,14 @@ public class FiwareInitiativeRepository extends FiwareRepository<Initiative> imp
 
     @Override
     protected Initiative fromNGSIJson(NGSIJson json) {
-
         final String id = json.getId();
         final String description = json.getString(Initiative.Fields.DESCRIPTION);
         final String image = json.getString(Initiative.Fields.IMAGE);
         final String nickname = json.getString(Initiative.Fields.NICKNAME);
-        final LocalDateTime date =  LocalDateTime.parse( json.getString(Initiative.Fields.DATE));
+
+        final long milli = json.getLong(Initiative.Fields.DATE.label());
+        final LocalDateTime date = DateUtil.milliToDateUTC(milli);
+
         final String userId = json.getString(Initiative.Fields.USER_ID);
         final int statusId = InitiativeStatus.fromIdOrElseThrow(json.getInt(Initiative.Fields.STATUS_ID)).getId();
 
@@ -55,5 +63,37 @@ public class FiwareInitiativeRepository extends FiwareRepository<Initiative> imp
     @Override
     public Optional<Initiative> findInitiativeById(String id) {
         return findById(id);
+    }
+
+    @Override
+    public List<Initiative> getAllInitiatives(InitiativeQuery query) {
+        final NGSIQueryBuilder queryBuilder = parseQuery(query);
+        return new ArrayList<>();
+    }
+
+    private NGSIQueryBuilder parseQuery(InitiativeQuery initiativeQuery) {
+        final NGSIQueryBuilder ngsiQueryBuilder = new NGSIQueryBuilder();
+
+        if (initiativeQuery.getUserId() != null) {
+            ngsiQueryBuilder.ref(User.NGSIType, initiativeQuery.getUserId());
+        }
+
+        if (initiativeQuery.getSorter() != null) {
+            if (initiativeQuery.getSorter() == InitiativeSorter.DATE_DESC) {
+                ngsiQueryBuilder.orderByDesc(Initiative.Fields.DATE);
+            }
+        }
+
+        if (initiativeQuery.getStatus() != null) {
+            ngsiQueryBuilder.attribute(Initiative.Fields.STATUS_ID, String.valueOf(initiativeQuery.getStatus().getId()));
+        }
+
+        // todo guardar milisegundos en iniciativas para poder comparar
+        if (initiativeQuery.getDateFrom() != null) {
+            final long millis = initiativeQuery.getDateFrom().atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
+
+        }
+
+        return ngsiQueryBuilder;
     }
 }

--- a/src/main/java/com/spochi/repository/fiware/FiwareRepository.java
+++ b/src/main/java/com/spochi/repository/fiware/FiwareRepository.java
@@ -11,10 +11,10 @@ import java.util.List;
 import java.util.Optional;
 public abstract class FiwareRepository<T extends NGSISerializable> {
     // PROD
-    // private static final String BASE_URL = "http://46.17.108.37:1026/v2";
+    private static final String BASE_URL = "http://46.17.108.37:1026/v2";
 
     // LOCAL
-    private static final String BASE_URL = "http://localhost:1026/v2";
+    // private static final String BASE_URL = "http://localhost:1026/v2";
     private static final String ENTITIES_URL = BASE_URL + "/entities";
 
     private final RestPerformer performer;

--- a/src/main/java/com/spochi/repository/fiware/FiwareRepository.java
+++ b/src/main/java/com/spochi/repository/fiware/FiwareRepository.java
@@ -11,10 +11,10 @@ import java.util.List;
 import java.util.Optional;
 public abstract class FiwareRepository<T extends NGSISerializable> {
     // PROD
-    private static final String BASE_URL = "http://46.17.108.37:1026/v2";
+    // private static final String BASE_URL = "http://46.17.108.37:1026/v2";
 
     // LOCAL
-    // private static final String BASE_URL = "http://localhost:1026/v2";
+    private static final String BASE_URL = "http://localhost:1026/v2";
     private static final String ENTITIES_URL = BASE_URL + "/entities";
 
     private final RestPerformer performer;

--- a/src/main/java/com/spochi/repository/fiware/FiwareUserRepository.java
+++ b/src/main/java/com/spochi/repository/fiware/FiwareUserRepository.java
@@ -47,7 +47,7 @@ public class FiwareUserRepository extends FiwareRepository<User> implements User
     @Override
     public Optional<User> findByNickname(String nickname) {
         final NGSIQueryBuilder queryBuilder = new NGSIQueryBuilder();
-        queryBuilder.attribute(User.Fields.NICKNAME, nickname);
+        queryBuilder.attributeEq(User.Fields.NICKNAME, nickname);
 
         return findFirst(queryBuilder);
     }

--- a/src/main/java/com/spochi/repository/fiware/ngsi/NGSIFieldType.java
+++ b/src/main/java/com/spochi/repository/fiware/ngsi/NGSIFieldType.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 public enum NGSIFieldType {
     TEXT("Text", String.class),
     INTEGER("Number", Integer.class),
+    LONG("Number", Long.class),
     DATE("LocalDateTime", String.class) {
         @Override
         public void validateValue(Object value) {

--- a/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
+++ b/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
@@ -16,8 +16,20 @@ public class NGSIQueryBuilder {
         return this;
     }
 
-    public NGSIQueryBuilder attribute(NGSIField attribute, String value) {
-        params.put("q=" + attribute.label() + "=", value);
+    public NGSIQueryBuilder attributeEq(NGSIField attribute, String value) {
+        final String key = "q=" + attribute.label() + "=";
+
+        if (params.containsKey(key)) {
+            params.put(key, params.get(key) + "," + value);
+        } else {
+            params.put(key, value);
+        }
+
+        return this;
+    }
+
+    public NGSIQueryBuilder attributeLs(NGSIField attribute, String value) {
+        params.put("q=" + attribute.label() + "<", value);
         return this;
     }
 
@@ -55,6 +67,11 @@ public class NGSIQueryBuilder {
         return this;
     }
 
+    public NGSIQueryBuilder offset(int offset) {
+        params.put("offset", String.valueOf(offset));
+        return this;
+    }
+
 
     public String build() {
         if (params.isEmpty()) return "";
@@ -62,7 +79,7 @@ public class NGSIQueryBuilder {
         return "?" + this.params.entrySet().stream().map(entry -> {
             String key = entry.getKey();
             String value = entry.getValue();
-            return key + "=" + value;
+            return key.contains("<") ? key + value : key + "=" + value;
         }).collect(Collectors.joining("&"));
     }
 }

--- a/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
+++ b/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
@@ -79,7 +79,15 @@ public class NGSIQueryBuilder {
         return "?" + this.params.entrySet().stream().map(entry -> {
             String key = entry.getKey();
             String value = entry.getValue();
-            return key.contains("<") ? key + value : key + "=" + value;
+            return key + comparator(key) + value;
         }).collect(Collectors.joining("&"));
+    }
+
+    private String comparator(String key) {
+        if (key.contains("<") || key.contains(">")) {
+            return "";
+        } else {
+            return "=";
+        }
     }
 }

--- a/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
+++ b/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
@@ -83,7 +83,7 @@ public class NGSIQueryBuilder {
         }).collect(Collectors.joining("&"));
     }
 
-    private String comparator(String key) {
+    protected static String comparator(String key) {
         if (key.contains("<") || key.contains(">")) {
             return "";
         } else {

--- a/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
+++ b/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
@@ -84,7 +84,7 @@ public class NGSIQueryBuilder {
     }
 
     protected static String comparator(String key) {
-        if (key.contains("<") || key.contains(">")) {
+        if (key.endsWith("<") || key.endsWith(">")) {
             return "";
         } else {
             return "=";

--- a/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
+++ b/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
@@ -5,11 +5,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class NGSIQueryBuilder {
-    private static final String Q = "q";
+    private static final String Q_KEY = "q";
     private static final String SIMPLE_EQ = "=";
-    private static final String EQ = "==";
+    private static final String DOUBLE_EQ = "==";
     private static final String LS = "<";
-
+    private static final String GT = ">";
+    private static final String Q_SEPARATOR = ";";
+    private static final String BLANK = "";
 
     private final Map<String, String> params;
 
@@ -23,7 +25,7 @@ public class NGSIQueryBuilder {
     }
 
     public NGSIQueryBuilder attributeEq(NGSIField attribute, String ... values) {
-        return qExpression(attribute.label() + EQ + String.join(",", values));
+        return qExpression(attribute.label() + DOUBLE_EQ + String.join(",", values));
     }
 
     public NGSIQueryBuilder attributeLs(NGSIField attribute, String value) {
@@ -60,7 +62,7 @@ public class NGSIQueryBuilder {
     }
 
     public NGSIQueryBuilder ref(NGSIEntityType type, String id) {
-        return qExpression("ref" + type.label() + EQ + id);
+        return qExpression("ref" + type.label() + DOUBLE_EQ + id);
     }
 
     public NGSIQueryBuilder offset(int offset) {
@@ -80,18 +82,18 @@ public class NGSIQueryBuilder {
     }
 
     protected static String comparator(String key) {
-        if (key.endsWith(LS) || key.endsWith(">")) {
-            return "";
+        if (key.endsWith(LS) || key.endsWith(GT)) {
+            return BLANK;
         } else {
             return SIMPLE_EQ;
         }
     }
 
     private NGSIQueryBuilder qExpression(String expression) {
-        if (params.containsKey(Q)) {
-            params.put(Q, params.get(Q) + ";" + expression);
+        if (params.containsKey(Q_KEY)) {
+            params.put(Q_KEY, params.get(Q_KEY) + Q_SEPARATOR + expression);
         } else {
-            params.put(Q, expression);
+            params.put(Q_KEY, expression);
         }
 
         return this;

--- a/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
+++ b/src/main/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilder.java
@@ -5,6 +5,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class NGSIQueryBuilder {
+    private static final String Q = "q";
+    private static final String SIMPLE_EQ = "=";
+    private static final String EQ = "==";
+    private static final String LS = "<";
+
+
     private final Map<String, String> params;
 
     public NGSIQueryBuilder() {
@@ -16,21 +22,12 @@ public class NGSIQueryBuilder {
         return this;
     }
 
-    public NGSIQueryBuilder attributeEq(NGSIField attribute, String value) {
-        final String key = "q=" + attribute.label() + "=";
-
-        if (params.containsKey(key)) {
-            params.put(key, params.get(key) + "," + value);
-        } else {
-            params.put(key, value);
-        }
-
-        return this;
+    public NGSIQueryBuilder attributeEq(NGSIField attribute, String ... values) {
+        return qExpression(attribute.label() + EQ + String.join(",", values));
     }
 
     public NGSIQueryBuilder attributeLs(NGSIField attribute, String value) {
-        params.put("q=" + attribute.label() + "<", value);
-        return this;
+        return qExpression(attribute.label() + LS + value);
     }
 
     public NGSIQueryBuilder count() {
@@ -63,8 +60,7 @@ public class NGSIQueryBuilder {
     }
 
     public NGSIQueryBuilder ref(NGSIEntityType type, String id) {
-        params.put("q=ref" + type.label() + "=", id);
-        return this;
+        return qExpression("ref" + type.label() + EQ + id);
     }
 
     public NGSIQueryBuilder offset(int offset) {
@@ -84,10 +80,20 @@ public class NGSIQueryBuilder {
     }
 
     protected static String comparator(String key) {
-        if (key.endsWith("<") || key.endsWith(">")) {
+        if (key.endsWith(LS) || key.endsWith(">")) {
             return "";
         } else {
-            return "=";
+            return SIMPLE_EQ;
         }
+    }
+
+    private NGSIQueryBuilder qExpression(String expression) {
+        if (params.containsKey(Q)) {
+            params.put(Q, params.get(Q) + ";" + expression);
+        } else {
+            params.put(Q, expression);
+        }
+
+        return this;
     }
 }

--- a/src/main/java/com/spochi/service/InitiativeService.java
+++ b/src/main/java/com/spochi/service/InitiativeService.java
@@ -9,13 +9,14 @@ import com.spochi.entity.User;
 import com.spochi.repository.InitiativeRepository;
 import com.spochi.repository.UserRepository;
 import com.spochi.service.query.InitiativeQuery;
-import com.spochi.service.query.InitiativeSorter;
 import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,22 +27,7 @@ public class InitiativeService {
     @Autowired
     UserRepository userRepository;
 
-    // todo borrar
-    public List<InitiativeResponseDTO> getAll(InitiativeSorter sorter, String uid) {
-        final User user = userRepository.findByUid(uid).orElseThrow(()-> new InitiativeServiceException("user not found when initiative getAll"));
-        final ArrayList<InitiativeResponseDTO> responseDTOS = new ArrayList<>();
-        final List<Initiative> orderedInitiatives = initiativeRepository.getAllInitiatives(sorter);
-
-        for (Initiative i : orderedInitiatives) {
-            responseDTOS.add(i.toDTO());
-        }
-
-        return responseDTOS;
-    }
-
-    // todo mover consulta al repo cuando es currentUser, borrar fromCurrentUser
     public List<InitiativeResponseDTO> getAll(InitiativeQuery query, String uid, boolean currentUser) {
-
         if (currentUser) {
             final User user = userRepository.findByUid(uid).orElseThrow(()-> new InitiativeServiceException("user not found when initiative getAll"));
             query.withUserId(user.getId());

--- a/src/main/java/com/spochi/service/InitiativeService.java
+++ b/src/main/java/com/spochi/service/InitiativeService.java
@@ -8,6 +8,7 @@ import com.spochi.entity.InitiativeStatus;
 import com.spochi.entity.User;
 import com.spochi.repository.InitiativeRepository;
 import com.spochi.repository.UserRepository;
+import com.spochi.service.query.InitiativeQuery;
 import com.spochi.service.query.InitiativeSorter;
 import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,23 @@ public class InitiativeService {
         final User user = userRepository.findByUid(uid).orElseThrow(()-> new InitiativeServiceException("user not found when initiative getAll"));
         final ArrayList<InitiativeResponseDTO> responseDTOS = new ArrayList<>();
         final List<Initiative> orderedInitiatives = initiativeRepository.getAllInitiatives(sorter);
+
+        for (Initiative i : orderedInitiatives) {
+            responseDTOS.add(i.toDTO(user.getId()));
+        }
+
+        return responseDTOS;
+    }
+
+    public List<InitiativeResponseDTO> getAll(InitiativeQuery query, String uid, boolean currentUser) {
+        final User user = userRepository.findByUid(uid).orElseThrow(()-> new InitiativeServiceException("user not found when initiative getAll"));
+        final ArrayList<InitiativeResponseDTO> responseDTOS = new ArrayList<>();
+
+        if (currentUser) {
+            query.withUserId(user.getId());
+        }
+
+        final List<Initiative> orderedInitiatives = initiativeRepository.getAllInitiatives(query);
 
         for (Initiative i : orderedInitiatives) {
             responseDTOS.add(i.toDTO(user.getId()));

--- a/src/main/java/com/spochi/service/InitiativeService.java
+++ b/src/main/java/com/spochi/service/InitiativeService.java
@@ -33,15 +33,14 @@ public class InitiativeService {
             query.withUserId(user.getId());
         }
 
-        final List<Initiative> orderedInitiatives = initiativeRepository.getAllInitiatives(query);
+        final List<Initiative> initiatives = initiativeRepository.getAllInitiatives(query);
 
-        return orderedInitiatives.stream().map(Initiative::toDTO).collect(Collectors.toList());
+        return initiatives.stream().map(Initiative::toDTO).collect(Collectors.toList());
     }
 
     public InitiativeResponseDTO create(InitiativeRequestDTO request, String uid) {
         final User user;
         final Initiative initiative;
-        final InitiativeResponseDTO responseDTO;
 
         validateFields(request);
 
@@ -61,10 +60,9 @@ public class InitiativeService {
                 InitiativeStatus.PENDING.getId()
         );
 
-        initiativeRepository.create(initiative);
-        responseDTO = initiative.toDTO();
+        final Initiative initiativeCreated = initiativeRepository.create(initiative);
 
-        return responseDTO;
+        return initiativeCreated.toDTO();
     }
 
     private void validateFields(InitiativeRequestDTO request) throws InitiativeServiceException {

--- a/src/main/java/com/spochi/service/InitiativeService.java
+++ b/src/main/java/com/spochi/service/InitiativeService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class InitiativeService {
@@ -25,33 +26,30 @@ public class InitiativeService {
     @Autowired
     UserRepository userRepository;
 
+    // todo borrar
     public List<InitiativeResponseDTO> getAll(InitiativeSorter sorter, String uid) {
         final User user = userRepository.findByUid(uid).orElseThrow(()-> new InitiativeServiceException("user not found when initiative getAll"));
         final ArrayList<InitiativeResponseDTO> responseDTOS = new ArrayList<>();
         final List<Initiative> orderedInitiatives = initiativeRepository.getAllInitiatives(sorter);
 
         for (Initiative i : orderedInitiatives) {
-            responseDTOS.add(i.toDTO(user.getId()));
+            responseDTOS.add(i.toDTO());
         }
 
         return responseDTOS;
     }
 
+    // todo mover consulta al repo cuando es currentUser, borrar fromCurrentUser
     public List<InitiativeResponseDTO> getAll(InitiativeQuery query, String uid, boolean currentUser) {
-        final User user = userRepository.findByUid(uid).orElseThrow(()-> new InitiativeServiceException("user not found when initiative getAll"));
-        final ArrayList<InitiativeResponseDTO> responseDTOS = new ArrayList<>();
 
         if (currentUser) {
+            final User user = userRepository.findByUid(uid).orElseThrow(()-> new InitiativeServiceException("user not found when initiative getAll"));
             query.withUserId(user.getId());
         }
 
         final List<Initiative> orderedInitiatives = initiativeRepository.getAllInitiatives(query);
 
-        for (Initiative i : orderedInitiatives) {
-            responseDTOS.add(i.toDTO(user.getId()));
-        }
-
-        return responseDTOS;
+        return orderedInitiatives.stream().map(Initiative::toDTO).collect(Collectors.toList());
     }
 
     public InitiativeResponseDTO create(InitiativeRequestDTO request, String uid) {
@@ -78,7 +76,7 @@ public class InitiativeService {
         );
 
         initiativeRepository.create(initiative);
-        responseDTO = initiative.toDTO(user.getId());
+        responseDTO = initiative.toDTO();
 
         return responseDTO;
     }

--- a/src/main/java/com/spochi/service/query/InitiativeQuery.java
+++ b/src/main/java/com/spochi/service/query/InitiativeQuery.java
@@ -17,6 +17,7 @@ public class InitiativeQuery {
     private String userId;
     private LocalDateTime dateTop;
     private Integer limit;
+    private Integer offset;
 
     public void withSorter(@Nullable Integer sorterId) {
         if (sorterId != null) {
@@ -43,6 +44,12 @@ public class InitiativeQuery {
     public void withLimit(@Nullable Integer limit) {
         if (limit != null) {
             this.limit = limit;
+        }
+    }
+
+    public void withOffset(Integer offset) {
+        if (offset != null) {
+            this.offset = offset;
         }
     }
 }

--- a/src/main/java/com/spochi/service/query/InitiativeQuery.java
+++ b/src/main/java/com/spochi/service/query/InitiativeQuery.java
@@ -1,0 +1,38 @@
+package com.spochi.service.query;
+
+import com.spochi.entity.InitiativeStatus;
+import com.sun.istack.NotNull;
+import com.sun.istack.Nullable;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class InitiativeQuery {
+    private InitiativeSorter sorter;
+    private InitiativeStatus status;
+    private String userId;
+    private LocalDateTime dateFrom;
+
+    public void withSorter(@Nullable Integer sorterId) {
+        if (sorterId != null) {
+            this.sorter = InitiativeSorter.fromIdOrElseThrow(sorterId);
+        }
+    }
+
+    public void withStatus(@Nullable Integer statusId) {
+        if (statusId != null) {
+            this.status = InitiativeStatus.fromIdOrElseThrow(statusId);
+        }
+    }
+
+    public void withUserId(@NotNull String userId) {
+        this.userId = userId;
+    }
+
+    public void withDateFrom(@Nullable String dateFrom) {
+        if (dateFrom != null) {
+            this.dateFrom = LocalDateTime.parse(dateFrom);
+        }
+    }
+}

--- a/src/main/java/com/spochi/service/query/InitiativeQuery.java
+++ b/src/main/java/com/spochi/service/query/InitiativeQuery.java
@@ -6,13 +6,17 @@ import com.sun.istack.Nullable;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class InitiativeQuery {
     private InitiativeSorter sorter;
-    private InitiativeStatus status;
+    private List<InitiativeStatus> statuses;
     private String userId;
-    private LocalDateTime dateFrom;
+    private LocalDateTime dateTop;
+    private Integer limit;
 
     public void withSorter(@Nullable Integer sorterId) {
         if (sorterId != null) {
@@ -20,9 +24,9 @@ public class InitiativeQuery {
         }
     }
 
-    public void withStatus(@Nullable Integer statusId) {
+    public void withStatuses(@Nullable Integer[] statusId) {
         if (statusId != null) {
-            this.status = InitiativeStatus.fromIdOrElseThrow(statusId);
+            this.statuses = Arrays.stream(statusId).map(InitiativeStatus::fromIdOrElseThrow).collect(Collectors.toList());
         }
     }
 
@@ -30,9 +34,15 @@ public class InitiativeQuery {
         this.userId = userId;
     }
 
-    public void withDateFrom(@Nullable String dateFrom) {
+    public void withDateTop(@Nullable String dateFrom) {
         if (dateFrom != null) {
-            this.dateFrom = LocalDateTime.parse(dateFrom);
+            this.dateTop = LocalDateTime.parse(dateFrom);
+        }
+    }
+
+    public void withLimit(@Nullable Integer limit) {
+        if (limit != null) {
+            this.limit = limit;
         }
     }
 }

--- a/src/main/java/com/spochi/service/query/InitiativeQuery.java
+++ b/src/main/java/com/spochi/service/query/InitiativeQuery.java
@@ -35,20 +35,20 @@ public class InitiativeQuery {
         this.userId = userId;
     }
 
-    public void withDateTop(@Nullable String dateFrom) {
-        if (dateFrom != null) {
-            this.dateTop = LocalDateTime.parse(dateFrom);
+    public void withDateTop(@Nullable String dateTop) {
+        if (dateTop != null) {
+            this.dateTop = LocalDateTime.parse(dateTop);
         }
     }
 
     public void withLimit(@Nullable Integer limit) {
-        if (limit != null) {
+        if (limit != null && limit > 0) {
             this.limit = limit;
         }
     }
 
     public void withOffset(Integer offset) {
-        if (offset != null) {
+        if (offset != null && offset > 0) {
             this.offset = offset;
         }
     }

--- a/src/main/java/com/spochi/util/DateUtil.java
+++ b/src/main/java/com/spochi/util/DateUtil.java
@@ -1,0 +1,16 @@
+package com.spochi.util;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public class DateUtil {
+
+    public static long dateToMilliUTC(LocalDateTime date) {
+        return date.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
+    }
+
+    public static LocalDateTime milliToDateUTC(long milli) {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(milli), ZoneId.of("UTC"));
+    }
+}

--- a/src/test/java/com/spochi/auth/JwtFilterTest.java
+++ b/src/test/java/com/spochi/auth/JwtFilterTest.java
@@ -1,6 +1,5 @@
 package com.spochi.auth;
 
-import com.spochi.entity.User;
 import com.spochi.repository.UserRepository;
 import com.spochi.service.auth.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,11 +17,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 import javax.servlet.http.HttpServletResponse;
 
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/src/test/java/com/spochi/controller/InitiativeTestUtil.java
+++ b/src/test/java/com/spochi/controller/InitiativeTestUtil.java
@@ -2,7 +2,6 @@ package com.spochi.controller;
 
 import com.spochi.dto.InitiativeResponseDTO;
 import com.spochi.entity.Initiative;
-import org.h2.value.ValueStringIgnoreCase;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -10,8 +9,6 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.mockito.ArgumentMatchers.anyString;
 
 public class InitiativeTestUtil {
     private static final List<Initiative> initiatives = new ArrayList<>();

--- a/src/test/java/com/spochi/controller/InitiativeTestUtil.java
+++ b/src/test/java/com/spochi/controller/InitiativeTestUtil.java
@@ -36,7 +36,7 @@ public class InitiativeTestUtil {
     }
 
     public static List<InitiativeResponseDTO> getAllAsDTOs(String user) {
-        return initiatives.stream().map(initiative -> initiative.toDTO(user)).collect(Collectors.toList());
+        return initiatives.stream().map(Initiative::toDTO).collect(Collectors.toList());
     }
 
     public static List<Initiative> getInitiatives() {

--- a/src/test/java/com/spochi/dto/InitiativeResponseDTOTest.java
+++ b/src/test/java/com/spochi/dto/InitiativeResponseDTOTest.java
@@ -1,6 +1,7 @@
 package com.spochi.dto;
 
 import com.spochi.entity.Initiative;
+import com.spochi.entity.InitiativeStatus;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -17,23 +18,24 @@ class InitiativeResponseDTOTest {
         final LocalDateTime date = LocalDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC"));
         final String description = "description";
         final String image = "image";
-        final String user = "user_";
+        final String userId = "user_id";
 
         final Initiative initiative = new Initiative();
         initiative.setImage(image);
         initiative.setNickname(nickname);
         initiative.setDate(date);
-        initiative.setStatusId(2);
-        initiative.setUserId(user);
+        initiative.setStatusId(InitiativeStatus.APPROVED.getId());
+        initiative.setUserId(userId);
+        initiative.setDescription(description);
 
-        final InitiativeResponseDTO dto = initiative.toDTO(user);
+        final InitiativeResponseDTO dto = initiative.toDTO();
 
-        assertEquals(initiative.getNickname(),dto.getNickname());
-        assertEquals(initiative.getDate().toString(),dto.getDate());
-        assertEquals(initiative.getDescription(),dto.getDescription());
-        assertEquals(initiative.getImage(),dto.getImage());
-        assertEquals(initiative.getStatusId(),dto.getStatus_id());
-        assertTrue(dto.isFrom_current_user());
+        assertEquals(initiative.getNickname(), dto.getNickname());
+        assertEquals(initiative.getDate().toString(), dto.getDate());
+        assertEquals(initiative.getDescription(), dto.getDescription());
+        assertEquals(initiative.getImage(), dto.getImage());
+        assertEquals(initiative.getStatusId(), dto.getStatus_id());
+        assertEquals(initiative.getDescription(), dto.getDescription());
     }
 
 }

--- a/src/test/java/com/spochi/persistence/InitiativeTest.java
+++ b/src/test/java/com/spochi/persistence/InitiativeTest.java
@@ -151,6 +151,23 @@ class InitiativeTest {
     }
 
     @Test
+    @DisplayName("dto equals | ok")
+    void dtoEqualsOk() {
+        final Initiative.InitiativeBuilder builder = Initiative.builder();
+        builder.nickname("author");
+        builder.date(LocalDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")));
+        builder.description("description");
+        builder.statusId(2);
+        builder.image("image");
+        builder.userId("user-id");
+
+        final Initiative initiative1 = builder.build();
+        final Initiative initiative2 = builder.build();
+
+        assertEquals(initiative1.toDTO(), initiative2.toDTO());
+    }
+
+    @Test
     @DisplayName("get entity type | ok")
     void getEntityTypeOk() {
         assertEquals("Initiative", Initiative.NGSIType.label());

--- a/src/test/java/com/spochi/persistence/InitiativeTest.java
+++ b/src/test/java/com/spochi/persistence/InitiativeTest.java
@@ -5,6 +5,7 @@ import com.spochi.entity.Initiative;
 import com.spochi.repository.MongoInitiativeRepositoryInterface;
 import com.spochi.repository.fiware.ngsi.NGSICommonFields;
 import com.spochi.repository.fiware.ngsi.NGSIJson;
+import com.spochi.util.DateUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,11 +34,12 @@ class InitiativeTest {
     @Test
     @DisplayName("initiativeToJson | ok")
     void initiativeToJson() {
+        final LocalDateTime date = LocalDateTime.now();
 
         final Initiative testInitiative = new Initiative();
         testInitiative.set_id("test1");
         testInitiative.setUserId(NGSICommonFields.ID.prefix() + "userTest1");
-        testInitiative.setDate(LocalDateTime.now().withNano(0));
+        testInitiative.setDate(date);
         testInitiative.setNickname("nickname1");
         testInitiative.setDescription("Some description");
         testInitiative.setImage("myImage");
@@ -48,7 +50,7 @@ class InitiativeTest {
         assertAll("expectedJsonData",
                 () -> assertEquals(testInitiative.get_id(), json.getId()),
                 () -> assertEquals(testInitiative.getUserId(), json.getJSONObject(Initiative.Fields.USER_ID.label()).getString(NGSICommonFields.VALUE.label())),
-                () -> assertEquals(testInitiative.getDate().toString(), json.getJSONObject(Initiative.Fields.DATE.label()).getString(NGSICommonFields.VALUE.label())),
+                () -> assertEquals(DateUtil.dateToMilliUTC(date), json.getJSONObject(Initiative.Fields.DATE.label()).getLong(NGSICommonFields.VALUE.label())),
                 () -> assertEquals(testInitiative.getNickname(), json.getJSONObject(Initiative.Fields.NICKNAME.label()).getString(NGSICommonFields.VALUE.label())),
                 () -> assertEquals(testInitiative.getDescription(), json.getJSONObject(Initiative.Fields.DESCRIPTION.label()).getString(NGSICommonFields.VALUE.label())),
                 () -> assertEquals(testInitiative.getImage(), json.getJSONObject(Initiative.Fields.IMAGE.label()).getString(NGSICommonFields.VALUE.label())),

--- a/src/test/java/com/spochi/persistence/InitiativeTest.java
+++ b/src/test/java/com/spochi/persistence/InitiativeTest.java
@@ -157,30 +157,4 @@ class InitiativeTest {
         assertEquals("Initiative", Initiative.NGSIType.label());
     }
 
-    @Test
-    void testToDtoOK(){
-        final String userId = "user-id";
-        final LocalDateTime date = LocalDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC"));
-
-        final Initiative.InitiativeBuilder builder = Initiative.builder();
-        builder.nickname("author");
-        builder.date(date);
-        builder.description("description");
-        builder.statusId(2);
-        builder.image("image");
-        builder.userId(userId);
-
-
-        final InitiativeResponseDTO dtoFromCurrentUser = builder.build().toDTO(userId);
-        final InitiativeResponseDTO dtoNotFromCurrentUSer = builder.userId("otro_id").build().toDTO(userId);
-
-        assertTrue(dtoFromCurrentUser.isFrom_current_user());
-        assertFalse(dtoNotFromCurrentUSer.isFrom_current_user());
-
-        assertEquals("author",dtoFromCurrentUser.getNickname());
-        assertEquals(date.toString(),dtoFromCurrentUser.getDate());
-        assertEquals("description",dtoFromCurrentUser.getDescription());
-        assertEquals(2,dtoFromCurrentUser.getStatus_id());
-        assertEquals("image",dtoFromCurrentUser.getImage());
-    }
 }

--- a/src/test/java/com/spochi/persistence/InitiativeTest.java
+++ b/src/test/java/com/spochi/persistence/InitiativeTest.java
@@ -1,6 +1,5 @@
 package com.spochi.persistence;
 
-import com.spochi.dto.InitiativeResponseDTO;
 import com.spochi.entity.Initiative;
 import com.spochi.repository.MongoInitiativeRepositoryInterface;
 import com.spochi.repository.fiware.ngsi.NGSICommonFields;

--- a/src/test/java/com/spochi/repository/MongoInitiativeRepositoryInterface.java
+++ b/src/test/java/com/spochi/repository/MongoInitiativeRepositoryInterface.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 public interface MongoInitiativeRepositoryInterface extends MongoRepository<Initiative,String>, InitiativeRepository {
 
     @Override
-    default List<Initiative> getAllInitiatives(InitiativeQuery query){
+    default List<Initiative> getAllInitiatives(InitiativeQuery query) {
         final Stream<Initiative> initiatives = findAll().stream();
 
         final Comparator<Initiative> comparator = query.getSorter() != null ? query.getSorter().getComparator() : InitiativeSorter.DEFAULT_COMPARATOR.getComparator();
@@ -36,6 +36,7 @@ public interface MongoInitiativeRepositoryInterface extends MongoRepository<Init
 
     default Predicate<Initiative> parseQuery(InitiativeQuery initiativeQuery) {
         List<Predicate<Initiative>> predicates = new ArrayList<>();
+
         if (initiativeQuery.getUserId() != null) {
             predicates.add(i -> i.getUserId().equals(initiativeQuery.getUserId()));
         }
@@ -60,7 +61,7 @@ public interface MongoInitiativeRepositoryInterface extends MongoRepository<Init
     }
 
     @Override
-    default Optional<Initiative> findInitiativeById(String id){
+    default Optional<Initiative> findInitiativeById(String id) {
        return findById(id);
     }
 }

--- a/src/test/java/com/spochi/repository/MongoInitiativeRepositoryInterface.java
+++ b/src/test/java/com/spochi/repository/MongoInitiativeRepositoryInterface.java
@@ -1,16 +1,21 @@
 package com.spochi.repository;
 
-import com.spochi.dto.InitiativeResponseDTO;
 import com.spochi.entity.Initiative;
+import com.spochi.entity.InitiativeStatus;
+import com.spochi.entity.User;
+import com.spochi.service.query.InitiativeQuery;
 import com.spochi.service.query.InitiativeSorter;
+import com.spochi.util.DateUtil;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Primary;
-
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -18,14 +23,46 @@ import java.util.stream.Stream;
 @Primary
 public interface MongoInitiativeRepositoryInterface extends MongoRepository<Initiative,String>, InitiativeRepository {
 
-   @Override
-   default List<Initiative> getAllInitiatives(InitiativeSorter sorter){
+    @Override
+    default List<Initiative> getAllInitiatives(InitiativeSorter sorter){
 
        final Stream<Initiative> initiatives = findAll().stream();
        return initiatives
                .sorted(sorter.getComparator())
                .collect(Collectors.toList());
-   }
+    }
+
+    @Override
+    default List<Initiative> getAllInitiatives(InitiativeQuery query){
+        final Stream<Initiative> initiatives = findAll().stream();
+
+        final Predicate<Initiative> predicate = parseQuery(query);
+
+        return initiatives
+                .filter(predicate)
+                .sorted(query.getSorter().getComparator())
+                .collect(Collectors.toList());
+    }
+
+    default Predicate<Initiative> parseQuery(InitiativeQuery initiativeQuery) {
+        List<Predicate<Initiative>> predicates = new ArrayList<>();
+        if (initiativeQuery.getUserId() != null) {
+            predicates.add(i -> i.getUserId().equals(initiativeQuery.getUserId()));
+        }
+
+        if (initiativeQuery.getStatuses() != null) {
+            predicates.add(i -> initiativeQuery.getStatuses()
+                    .stream()
+                    .map(InitiativeStatus::getId)
+                    .anyMatch(s -> s == i.getStatusId()));
+        }
+
+        if (initiativeQuery.getDateTop() != null) {
+            predicates.add(i -> i.getDate().isBefore(initiativeQuery.getDateTop()));
+        }
+
+        return i -> predicates.stream().allMatch(p -> p.test(i));
+    };
 
     @Override
     default Initiative create(@NotNull Initiative initiative) {
@@ -33,7 +70,7 @@ public interface MongoInitiativeRepositoryInterface extends MongoRepository<Init
     }
 
     @Override
-   default Optional<Initiative> findInitiativeById(String id){
+    default Optional<Initiative> findInitiativeById(String id){
        return findById(id);
     }
 }

--- a/src/test/java/com/spochi/repository/MongoInitiativeRepositoryInterface.java
+++ b/src/test/java/com/spochi/repository/MongoInitiativeRepositoryInterface.java
@@ -2,17 +2,15 @@ package com.spochi.repository;
 
 import com.spochi.entity.Initiative;
 import com.spochi.entity.InitiativeStatus;
-import com.spochi.entity.User;
 import com.spochi.service.query.InitiativeQuery;
 import com.spochi.service.query.InitiativeSorter;
-import com.spochi.util.DateUtil;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -24,23 +22,15 @@ import java.util.stream.Stream;
 public interface MongoInitiativeRepositoryInterface extends MongoRepository<Initiative,String>, InitiativeRepository {
 
     @Override
-    default List<Initiative> getAllInitiatives(InitiativeSorter sorter){
-
-       final Stream<Initiative> initiatives = findAll().stream();
-       return initiatives
-               .sorted(sorter.getComparator())
-               .collect(Collectors.toList());
-    }
-
-    @Override
     default List<Initiative> getAllInitiatives(InitiativeQuery query){
         final Stream<Initiative> initiatives = findAll().stream();
 
+        final Comparator<Initiative> comparator = query.getSorter() != null ? query.getSorter().getComparator() : InitiativeSorter.DEFAULT_COMPARATOR.getComparator();
         final Predicate<Initiative> predicate = parseQuery(query);
 
         return initiatives
                 .filter(predicate)
-                .sorted(query.getSorter().getComparator())
+                .sorted(comparator)
                 .collect(Collectors.toList());
     }
 
@@ -62,7 +52,7 @@ public interface MongoInitiativeRepositoryInterface extends MongoRepository<Init
         }
 
         return i -> predicates.stream().allMatch(p -> p.test(i));
-    };
+    }
 
     @Override
     default Initiative create(@NotNull Initiative initiative) {

--- a/src/test/java/com/spochi/repository/MongoUserRepository.java
+++ b/src/test/java/com/spochi/repository/MongoUserRepository.java
@@ -1,6 +1,7 @@
 package com.spochi.repository;
 
 import com.spochi.entity.User;
+import com.spochi.service.query.InitiativeQuery;
 import com.spochi.service.query.InitiativeSorter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
@@ -36,7 +37,10 @@ public class MongoUserRepository implements UserRepository {
 
     @Override
     public int getAmountOfInitiatives(String id) {
-        return (int) initiativeRepository.getAllInitiatives(InitiativeSorter.DEFAULT_COMPARATOR)
+        final InitiativeQuery initiativeQuery = new InitiativeQuery();
+        initiativeQuery.withSorter(InitiativeSorter.DEFAULT_COMPARATOR.getId());
+
+        return (int) initiativeRepository.getAllInitiatives(initiativeQuery)
                 .stream()
                 .filter(i -> i.getUserId() != null && i.getUserId().equalsIgnoreCase(id))
                 .count();

--- a/src/test/java/com/spochi/repository/fiware/FiwareInitiativeRepositoryTest.java
+++ b/src/test/java/com/spochi/repository/fiware/FiwareInitiativeRepositoryTest.java
@@ -149,7 +149,7 @@ public class FiwareInitiativeRepositoryTest {
     }
 
     @Test
-    @DisplayName("getAll | no result | return an empty Json ")
+    @DisplayName("getAll | no result | should return an empty Json ")
     void getAllInitiativesWithoutHavingCreated() {
 
         final RestPerformer performer = mock(RestPerformer.class);

--- a/src/test/java/com/spochi/repository/fiware/FiwareInitiativeRepositoryTest.java
+++ b/src/test/java/com/spochi/repository/fiware/FiwareInitiativeRepositoryTest.java
@@ -5,6 +5,7 @@ import com.spochi.repository.fiware.ngsi.NGSIFieldType;
 import com.spochi.repository.fiware.ngsi.NGSIJson;
 import com.spochi.repository.fiware.rest.RestPerformer;
 import com.spochi.service.query.InitiativeSorter;
+import com.spochi.util.DateUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -58,24 +59,6 @@ public class FiwareInitiativeRepositoryTest {
     }
 
     @Test
-    @DisplayName("ToNGSIJson | returns initiative")
-    void toNGSIJsonOk() {
-        final RestPerformer performer = mock(RestPerformer.class);
-        final FiwareInitiativeRepository repository = new FiwareInitiativeRepository(performer);
-        final Initiative testInitiative = repository.fromNGSIJson(initiative1Json);
-
-        assertAll("Expected initiative",
-                () -> assertEquals(testInitiative.get_id(), id1),
-                () -> assertEquals(testInitiative.getUserId(), initiative1Json.getString(Initiative.Fields.USER_ID)),
-                () -> assertEquals(testInitiative.getDate().toString(), initiative1Json.getString(Initiative.Fields.DATE)),
-                () -> assertEquals(testInitiative.getDescription(), initiative1Json.getString(Initiative.Fields.DESCRIPTION)),
-                () -> assertEquals(testInitiative.getNickname(), initiative1Json.getString(Initiative.Fields.NICKNAME)),
-                () -> assertEquals(testInitiative.getStatusId(), initiative1Json.getInt(Initiative.Fields.STATUS_ID)),
-                () -> assertEquals(testInitiative.getImage(), initiative1Json.getString(Initiative.Fields.IMAGE))
-        );
-    }
-
-    @Test
     @DisplayName("InitiativeFieldsTest | Ok")
     void initiativeFieldsTest() {
         String id = "id";
@@ -85,10 +68,6 @@ public class FiwareInitiativeRepositoryTest {
         String date = "date";
         String userId = "refUser";
         String statusId = "status_id";
-        NGSIFieldType idType = NGSIFieldType.INTEGER;
-        NGSIFieldType textType = NGSIFieldType.TEXT;
-        NGSIFieldType dateType = NGSIFieldType.DATE;
-        NGSIFieldType referenceType = NGSIFieldType.REFERENCE;
 
         assertAll("Labels",
                 () -> assertEquals(id, Initiative.Fields.ID.label()),
@@ -100,15 +79,18 @@ public class FiwareInitiativeRepositoryTest {
                 () -> assertEquals(statusId, Initiative.Fields.STATUS_ID.label()));
 
         assertAll("Types",
-                () -> assertEquals(idType, Initiative.Fields.ID.type()),
-                () -> assertEquals(textType, Initiative.Fields.DESCRIPTION.type()),
-                () -> assertEquals(dateType, Initiative.Fields.DATE.type()),
-                () -> assertEquals(referenceType, Initiative.Fields.USER_ID.type()));
+                () -> assertEquals(NGSIFieldType.INTEGER, Initiative.Fields.ID.type()),
+                () -> assertEquals(NGSIFieldType.TEXT, Initiative.Fields.DESCRIPTION.type()),
+                () -> assertEquals(NGSIFieldType.TEXT, Initiative.Fields.NICKNAME.type()),
+                () -> assertEquals(NGSIFieldType.TEXT, Initiative.Fields.IMAGE.type()),
+                () -> assertEquals(NGSIFieldType.INTEGER, Initiative.Fields.STATUS_ID.type()),
+                () -> assertEquals(NGSIFieldType.LONG, Initiative.Fields.DATE.type()),
+                () -> assertEquals(NGSIFieldType.REFERENCE, Initiative.Fields.USER_ID.type()));
     }
 
     @Test
-    @DisplayName("getSerializatedInitiative | ok")
-    void getSerializatedInitiative() {
+    @DisplayName("fromNGSIJson | ok")
+    void fromNGSIJsonOk() {
         String description = "testDescription";
         String id = "200";
         int status = 1;
@@ -123,7 +105,7 @@ public class FiwareInitiativeRepositoryTest {
         json.put(Initiative.Fields.STATUS_ID.label(), status);
         json.put(Initiative.Fields.IMAGE.label(), image);
         json.put(Initiative.Fields.NICKNAME.label(), nickname);
-        json.put(Initiative.Fields.DATE.label(), date.toString());
+        json.put(Initiative.Fields.DATE.label(), DateUtil.dateToMilliUTC(date));
         json.put(Initiative.Fields.USER_ID.label(), userId);
 
         final FiwareInitiativeRepository repository = new FiwareInitiativeRepository(mock(RestPerformer.class));
@@ -135,7 +117,7 @@ public class FiwareInitiativeRepositoryTest {
                 () -> assertEquals(status, testInitiative.getStatusId()),
                 () -> assertEquals(image, testInitiative.getImage()),
                 () -> assertEquals(nickname, testInitiative.getNickname()),
-                () -> assertEquals(date, testInitiative.getDate()),
+                () -> assertEquals(date.withNano(0), testInitiative.getDate().withNano(0)),
                 () -> assertEquals(userId, testInitiative.getUserId()));
     }
 
@@ -206,7 +188,7 @@ public class FiwareInitiativeRepositoryTest {
         json.put(Initiative.Fields.IMAGE.label(), initiative.getImage());
         json.put(Initiative.Fields.NICKNAME.label(), initiative.getNickname());
         json.put(Initiative.Fields.USER_ID.label(), initiative.getUserId());
-        json.put(Initiative.Fields.DATE.label(), initiative.getDate().withNano(0).toString());
+        json.put(Initiative.Fields.DATE.label(), DateUtil.dateToMilliUTC(initiative.getDate().withNano(0)));
 
         return json;
     }

--- a/src/test/java/com/spochi/repository/fiware/FiwareInitiativeRepositoryTest.java
+++ b/src/test/java/com/spochi/repository/fiware/FiwareInitiativeRepositoryTest.java
@@ -133,14 +133,14 @@ public class FiwareInitiativeRepositoryTest {
         initiativeQuery.withStatuses(new Integer[]{InitiativeStatus.APPROVED.getId()});
         initiativeQuery.withLimit(3);
         initiativeQuery.withOffset(1);
-        initiativeQuery.withSorter(InitiativeSorter.DEFAULT_COMPARATOR.getId());
+        initiativeQuery.withSorter(InitiativeSorter.DATE_DESC.getId());
         initiativeQuery.withUserId("user-id");
 
         when(performer.get(anyString())).thenReturn(bothInitiatives);
 
         final List<Initiative> initiatives = repository.getAllInitiatives(initiativeQuery);
 
-        verify(performer, times(1)).get(contains("/v2/entities?q=status_id==2&q=date<1586174400000&offset=1&limit=3&options=keyValues&type=Initiative&q=refUser==user-id"));
+        verify(performer, times(1)).get(contains("/v2/entities?q=status_id==2&q=date<1586174400000&offset=1&limit=3&options=keyValues&orderBy=!date&type=Initiative&q=refUser==user-id"));
 
         assertAll("Expected result",
                 () -> assertEquals(2, initiatives.size()),
@@ -168,7 +168,7 @@ public class FiwareInitiativeRepositoryTest {
         final RestPerformer performer = mock(RestPerformer.class);
         final FiwareInitiativeRepository repository = new FiwareInitiativeRepository(performer);
 
-        final Optional<Initiative> testInitiative = repository.findById(id1);
+        final Optional<Initiative> testInitiative = repository.findInitiativeById(id1);
     }
 
     private static NGSIJson buildTestInitiativeJsonResponse(Initiative initiative, String id1) {

--- a/src/test/java/com/spochi/repository/fiware/FiwareInitiativeRepositoryTest.java
+++ b/src/test/java/com/spochi/repository/fiware/FiwareInitiativeRepositoryTest.java
@@ -140,7 +140,7 @@ public class FiwareInitiativeRepositoryTest {
 
         final List<Initiative> initiatives = repository.getAllInitiatives(initiativeQuery);
 
-        verify(performer, times(1)).get(contains("/v2/entities?q=status_id==2&q=date<1586174400000&offset=1&limit=3&options=keyValues&orderBy=!date&type=Initiative&q=refUser==user-id"));
+        verify(performer, times(1)).get(contains("/v2/entities?q=refUser==user-id;status_id==2;date<1586174400000&offset=1&limit=3&options=keyValues&orderBy=!date&type=Initiative"));
 
         assertAll("Expected result",
                 () -> assertEquals(2, initiatives.size()),

--- a/src/test/java/com/spochi/repository/fiware/ngsi/NGSIFieldTypeTest.java
+++ b/src/test/java/com/spochi/repository/fiware/ngsi/NGSIFieldTypeTest.java
@@ -16,6 +16,7 @@ class NGSIFieldTypeTest {
     void getName() {
         assertEquals("Text", TEXT.label());
         assertEquals("Number", INTEGER.label());
+        assertEquals("Number", LONG.label());
         assertEquals("LocalDateTime", DATE.label());
         assertEquals("Reference", REFERENCE.label());
     }
@@ -37,6 +38,16 @@ class NGSIFieldTypeTest {
         assertException(InvalidValueException.class, () -> INTEGER.validateValue(10.4d), "Type Number expected an instance of Integer but [10.4] is a Double");
         assertException(InvalidValueException.class, () -> INTEGER.validateValue("a-text"), "Type Number expected an instance of Integer but [a-text] is a String");
         assertException(InvalidValueException.class, () -> INTEGER.validateValue(null), "Null values are not allowed");
+    }
+
+    @Test
+    @DisplayName("validate value | when type is LONG")
+    void validateValueLong() {
+        assertDoesNotThrow(() -> LONG.validateValue(10L));
+
+        assertException(InvalidValueException.class, () -> LONG.validateValue(1), "Type Number expected an instance of Long but [1] is a Integer");
+        assertException(InvalidValueException.class, () -> LONG.validateValue("a-text"), "Type Number expected an instance of Long but [a-text] is a String");
+        assertException(InvalidValueException.class, () -> LONG.validateValue(null), "Null values are not allowed");
     }
 
     @Test

--- a/src/test/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilderTest.java
+++ b/src/test/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilderTest.java
@@ -42,8 +42,7 @@ class NGSIQueryBuilderTest {
     @DisplayName("build | with multiple values for same attributeEq | ok")
     void buildWithMultipleAttributeEqOk() {
         final NGSIQueryBuilder queryBuilder = new NGSIQueryBuilder();
-        queryBuilder.attributeEq(NGSITestFields.A_ATTRIBUTE, "aValue");
-        queryBuilder.attributeEq(NGSITestFields.A_ATTRIBUTE, "bValue");
+        queryBuilder.attributeEq(NGSITestFields.A_ATTRIBUTE, "aValue", "bValue");
 
         assertEquals("?q=aAttribute==aValue,bValue", queryBuilder.build());
     }
@@ -100,6 +99,17 @@ class NGSIQueryBuilderTest {
         queryBuilder.ref(testEntityType, "test-id");
 
         assertEquals("?q=reftestEntity==test-id", queryBuilder.build());
+    }
+
+    @Test
+    @DisplayName("build | ref eq two attributes and ls | ok")
+    void buildRefAndTwoAttributes() {
+        final NGSIQueryBuilder queryBuilder = new NGSIQueryBuilder();
+        queryBuilder.attributeEq(NGSITestFields.A_ATTRIBUTE, "aValue", "bValue");
+        queryBuilder.attributeLs(NGSITestFields.A_ATTRIBUTE, "cValue");
+        queryBuilder.ref(testEntityType, "test-id");
+
+        assertEquals("?q=aAttribute==aValue,bValue;aAttribute<cValue;reftestEntity==test-id", queryBuilder.build());
     }
 
     @Test

--- a/src/test/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilderTest.java
+++ b/src/test/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilderTest.java
@@ -152,4 +152,12 @@ class NGSIQueryBuilderTest {
         assertEquals("?q=bAttribute==bValue&offset=2&options=keyValues&limit=5&orderBy=!bOrder&type=testEntity&attr=bAttribute", queryBuilder.build());
     }
 
+    @Test
+    @DisplayName("comparator | ok")
+    void comparatorOk() {
+        assertEquals("=", NGSIQueryBuilder.comparator("key"));
+        assertEquals("", NGSIQueryBuilder.comparator("key>"));
+        assertEquals("", NGSIQueryBuilder.comparator("key<"));
+    }
+
 }

--- a/src/test/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilderTest.java
+++ b/src/test/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilderTest.java
@@ -30,12 +30,22 @@ class NGSIQueryBuilderTest {
     }
 
     @Test
-    @DisplayName("build | with attribute | ok")
-    void buildWithAttributeOk() {
+    @DisplayName("build | with single attribute | ok")
+    void buildWithSingleAttributeOk() {
         final NGSIQueryBuilder queryBuilder = new NGSIQueryBuilder();
-        queryBuilder.attribute(NGSITestFields.A_ATTRIBUTE, "aValue");
+        queryBuilder.attributeEq(NGSITestFields.A_ATTRIBUTE, "aValue");
 
         assertEquals("?q=aAttribute==aValue", queryBuilder.build());
+    }
+
+    @Test
+    @DisplayName("build | with multiple values for same attribute | ok")
+    void buildWithMultipleAttributesOk() {
+        final NGSIQueryBuilder queryBuilder = new NGSIQueryBuilder();
+        queryBuilder.attributeEq(NGSITestFields.A_ATTRIBUTE, "aValue");
+        queryBuilder.attributeEq(NGSITestFields.A_ATTRIBUTE, "bValue");
+
+        assertEquals("?q=aAttribute==aValue,bValue", queryBuilder.build());
     }
 
     @Test
@@ -105,6 +115,16 @@ class NGSIQueryBuilderTest {
     }
 
     @Test
+    @DisplayName("build | with offset | ok")
+    void buildWithOffsetOk() {
+        final NGSIQueryBuilder queryBuilder = new NGSIQueryBuilder();
+        queryBuilder.offset(1);
+
+        assertEquals("?offset=1", queryBuilder.build());
+    }
+
+
+    @Test
     @DisplayName("build | with multiple params | ok")
     void buildWithMultipleParamsOk() {
         final NGSIField field = mock(NGSIField.class);
@@ -113,14 +133,14 @@ class NGSIQueryBuilderTest {
         final NGSIQueryBuilder queryBuilder = new NGSIQueryBuilder();
 
         queryBuilder.type(testEntityType)
-                .attribute(NGSITestFields.B_ATTRIBUTE, "bValue")
+                .attributeEq(NGSITestFields.B_ATTRIBUTE, "bValue")
                 .getAttribute(NGSITestFields.B_ATTRIBUTE)
                 .keyValues()
+                .offset(2)
                 .orderByDesc(field)
                 .limit(5);
 
-
-        assertEquals("?q=bAttribute==bValue&options=keyValues&limit=5&orderBy=!bOrder&type=testEntity&attr=bAttribute", queryBuilder.build());
+        assertEquals("?q=bAttribute==bValue&offset=2&options=keyValues&limit=5&orderBy=!bOrder&type=testEntity&attr=bAttribute", queryBuilder.build());
     }
 
 }

--- a/src/test/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilderTest.java
+++ b/src/test/java/com/spochi/repository/fiware/ngsi/NGSIQueryBuilderTest.java
@@ -30,8 +30,8 @@ class NGSIQueryBuilderTest {
     }
 
     @Test
-    @DisplayName("build | with single attribute | ok")
-    void buildWithSingleAttributeOk() {
+    @DisplayName("build | with single attributeEq | ok")
+    void buildWithSingleAttributeEqOk() {
         final NGSIQueryBuilder queryBuilder = new NGSIQueryBuilder();
         queryBuilder.attributeEq(NGSITestFields.A_ATTRIBUTE, "aValue");
 
@@ -39,13 +39,22 @@ class NGSIQueryBuilderTest {
     }
 
     @Test
-    @DisplayName("build | with multiple values for same attribute | ok")
-    void buildWithMultipleAttributesOk() {
+    @DisplayName("build | with multiple values for same attributeEq | ok")
+    void buildWithMultipleAttributeEqOk() {
         final NGSIQueryBuilder queryBuilder = new NGSIQueryBuilder();
         queryBuilder.attributeEq(NGSITestFields.A_ATTRIBUTE, "aValue");
         queryBuilder.attributeEq(NGSITestFields.A_ATTRIBUTE, "bValue");
 
         assertEquals("?q=aAttribute==aValue,bValue", queryBuilder.build());
+    }
+
+    @Test
+    @DisplayName("build | with attributeLs | ok")
+    void buildWithSingleAttributeLsOk() {
+        final NGSIQueryBuilder queryBuilder = new NGSIQueryBuilder();
+        queryBuilder.attributeLs(NGSITestFields.A_ATTRIBUTE, "aValue");
+
+        assertEquals("?q=aAttribute<aValue", queryBuilder.build());
     }
 
     @Test

--- a/src/test/java/com/spochi/service/InitiativeServiceTest.java
+++ b/src/test/java/com/spochi/service/InitiativeServiceTest.java
@@ -9,6 +9,7 @@ import com.spochi.repository.InitiativeRepository;
 import com.spochi.repository.MongoUserRepository;
 import com.spochi.service.query.InitiativeSorter;
 import com.spochi.util.AssertUtils;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -124,6 +125,7 @@ class InitiativeServiceTest {
     }
 
     @Test
+    @DisplayName("Get all")
     void getAllInitiativeOK() {
         final InitiativeSorter sorter = InitiativeSorter.DEFAULT_COMPARATOR;
         final Initiative.InitiativeBuilder builder = Initiative.builder();
@@ -159,10 +161,6 @@ class InitiativeServiceTest {
        List<InitiativeResponseDTO> list_dto = service.getAll(sorter,UID);
 
        assertEquals(3,list_dto.size());
-       assertTrue(list_dto.get(0).isFrom_current_user());
-       assertTrue(list_dto.get(1).isFrom_current_user());
-       assertFalse(list_dto.get(2).isFrom_current_user());
-
     }
 
     @Test

--- a/src/test/java/com/spochi/service/InitiativeServiceTest.java
+++ b/src/test/java/com/spochi/service/InitiativeServiceTest.java
@@ -173,6 +173,7 @@ class InitiativeServiceTest {
         final Initiative initiativeFromCurrentUser_1 = builder.build();
         final Initiative initiativeFromCurrentUser_2 = builder._id("2").date(date.minusDays(4)).description("initiative-2").build();
 
+        builder.description("initiative-3");
         builder.userId("another_user");
         builder._id("3");
         builder.date(date.minusDays(5));

--- a/src/test/java/com/spochi/service/query/InitiativeQueryTest.java
+++ b/src/test/java/com/spochi/service/query/InitiativeQueryTest.java
@@ -1,0 +1,100 @@
+package com.spochi.service.query;
+
+import com.spochi.entity.InitiativeStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("InitiativeQuery test | Unit")
+class InitiativeQueryTest {
+
+    @Test
+    void withSorter() {
+        final InitiativeQuery query = new InitiativeQuery();
+
+        query.withSorter(null);
+        assertNull(query.getSorter());
+
+        query.withSorter(InitiativeSorter.DATE_DESC.getId());
+        assertEquals(InitiativeSorter.DATE_DESC, query.getSorter());
+
+        assertThrows(InitiativeSorter.InitiativeSorterNotFoundException.class, () -> query.withSorter(-4));
+    }
+
+    @Test
+    void withStatuses() {
+        final InitiativeQuery query = new InitiativeQuery();
+
+        query.withStatuses(null);
+        assertNull(query.getStatuses());
+
+        query.withStatuses(new Integer[]{InitiativeStatus.APPROVED.getId()});
+        assertEquals(1, query.getStatuses().size());
+        assertEquals(InitiativeStatus.APPROVED, query.getStatuses().get(0));
+
+        query.withStatuses(new Integer[]{InitiativeStatus.APPROVED.getId(), InitiativeStatus.PENDING.getId()});
+        assertEquals(2, query.getStatuses().size());
+        assertEquals(InitiativeStatus.APPROVED, query.getStatuses().get(0));
+        assertEquals(InitiativeStatus.PENDING, query.getStatuses().get(1));
+
+        assertThrows(InitiativeStatus.InitiativeStatusNotFoundException.class, () -> query.withStatuses(new Integer[]{-4}));
+    }
+
+    @Test
+    void withUserId() {
+        final InitiativeQuery query = new InitiativeQuery();
+
+        query.withUserId(null);
+        assertNull(query.getUserId());
+
+        query.withUserId("user-id");
+        assertEquals("user-id", query.getUserId());
+    }
+
+    @Test
+    void withDateTop() {
+        final InitiativeQuery query = new InitiativeQuery();
+
+        final LocalDateTime dateTop = LocalDateTime.now();
+
+        query.withDateTop(null);
+        assertNull(query.getDateTop());
+
+        query.withDateTop(dateTop.toString());
+        assertEquals(dateTop, query.getDateTop());
+
+        assertThrows(DateTimeParseException.class, () -> query.withDateTop("not-a-date"));
+    }
+
+    @Test
+    void withLimit() {
+        final InitiativeQuery query = new InitiativeQuery();
+
+        query.withLimit(null);
+        assertNull(query.getLimit());
+
+        query.withLimit(0);
+        assertNull(query.getLimit());
+
+        query.withLimit(5);
+        assertEquals(5, query.getLimit());
+    }
+
+    @Test
+    void withOffset() {
+        final InitiativeQuery query = new InitiativeQuery();
+
+        query.withOffset(null);
+        assertNull(query.getOffset());
+
+        query.withOffset(-2);
+        assertNull(query.getOffset());
+
+        query.withOffset(2);
+        assertEquals(2, query.getOffset());
+    }
+}

--- a/src/test/java/com/spochi/util/DateUtilTest.java
+++ b/src/test/java/com/spochi/util/DateUtilTest.java
@@ -15,7 +15,6 @@ class DateUtilTest {
     void dateToMilliUTC() {
         assertEquals(LocalDateTime.parse("2021-04-12T16:27:52.038"), DateUtil.milliToDateUTC(1618244872038L));
         assertEquals(LocalDateTime.parse("2019-01-23T11:35:21.021"), DateUtil.milliToDateUTC(1548243321021L));
-
     }
 
     @Test

--- a/src/test/java/com/spochi/util/DateUtilTest.java
+++ b/src/test/java/com/spochi/util/DateUtilTest.java
@@ -1,0 +1,27 @@
+package com.spochi.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("DateUtil test | Unit")
+class DateUtilTest {
+
+    @Test
+    @DisplayName("dateToMilliUTC | ok")
+    void dateToMilliUTC() {
+        assertEquals(LocalDateTime.parse("2021-04-12T16:27:52.038"), DateUtil.milliToDateUTC(1618244872038L));
+        assertEquals(LocalDateTime.parse("2019-01-23T11:35:21.021"), DateUtil.milliToDateUTC(1548243321021L));
+
+    }
+
+    @Test
+    @DisplayName("milliToDateUTC | ok")
+    void milliToDateUTC() {
+        assertEquals(1648242429221L, DateUtil.dateToMilliUTC(LocalDateTime.parse("2022-03-25T21:07:09.221")));
+        assertEquals(1623398123424L, DateUtil.dateToMilliUTC(LocalDateTime.parse("2021-06-11T07:55:23.424")));
+    }
+}


### PR DESCRIPTION
- Se agregan queryParams para filtrar Initiative en el getAll()
- Se cambia lógica de persistencia de Date en Initiative -> se guardan los milisegundos (long). Esto es para poder filtrar por fecha al hacer queries. Esto es solo en la base, a nivel modelo se sigue utilizando LocalDateTime
- Se cambia lógica de filtrar Initiative por usuario, lo cual posibilita eliminar el dato fromCurrentUser del dto.
